### PR TITLE
[WIP] resurrecting in place `ntoh`

### DIFF
--- a/src/custom.jl
+++ b/src/custom.jl
@@ -49,7 +49,7 @@ end
 The `interped_data` method specialized for `LorentzVector`. This method will get called by
 [`basketarray`](@ref) instead of the default method for `TLorentzVector` branch.
 """
-function interped_data(rawdata, rawoffsets, ::Type{Vector{LVF64}}, ::Type{Offsetjagg})
+function interped_data(rawdata, rawoffsets, ::Type{Vector{LVF64}}, ::Type{Offsetjagg}, ::Bool)
     _size = 64 # needs to account for 32 bytes header
     dp = 0 # book keeping for copy_to!
     lr = length(rawoffsets)
@@ -73,7 +73,7 @@ function interped_data(rawdata, rawoffsets, ::Type{Vector{LVF64}}, ::Type{Offset
     offset .+= 1
     VectorOfVectors(real_data, offset)
 end
-function interped_data(rawdata, rawoffsets, ::Type{LVF64}, ::Type{J}) where {T, J <: JaggType}
+function interped_data(rawdata, rawoffsets, ::Type{LVF64}, ::Type{J}, ::Bool) where {T, J <: JaggType}
     # even with rawoffsets, we know each TLV is destinied to be 64 bytes
     [
      reinterpret(LVF64, x) for x in Base.Iterators.partition(rawdata, 64)
@@ -91,7 +91,7 @@ end
 function readtype(io::IO, T::Type{_KM3NETDAQHit})
     T(readtype(io, Int32), read(io, UInt8), read(io, Int32), read(io, UInt8))
 end
-function interped_data(rawdata, rawoffsets, ::Type{Vector{_KM3NETDAQHit}}, ::Type{J}) where {T, J <: UnROOT.JaggType}
+function interped_data(rawdata, rawoffsets, ::Type{Vector{_KM3NETDAQHit}}, ::Type{J}, ::Bool) where {T, J <: UnROOT.JaggType}
     UnROOT.splitup(rawdata, rawoffsets, _KM3NETDAQHit, skipbytes=10)
 end
 
@@ -114,7 +114,7 @@ function readtype(io::IO, T::Type{_KM3NETDAQTriggeredHit})
     T(dom_id, channel_id, tdc, tot, trigger_mask)
 end
 
-function UnROOT.interped_data(rawdata, rawoffsets, ::Type{Vector{_KM3NETDAQTriggeredHit}}, ::Type{J}) where {T, J <: UnROOT.JaggType}
+function UnROOT.interped_data(rawdata, rawoffsets, ::Type{Vector{_KM3NETDAQTriggeredHit}}, ::Type{J}, ::Bool) where {T, J <: UnROOT.JaggType}
     UnROOT.splitup(rawdata, rawoffsets, _KM3NETDAQTriggeredHit, skipbytes=10)
 end
 
@@ -146,6 +146,6 @@ function readtype(io::IO, T::Type{_KM3NETDAQEventHeader})
     T(detector_id, run, frame_index, UTC_seconds, UTC_16nanosecondcycles, trigger_counter, trigger_mask, overlays)
 end
 
-function UnROOT.interped_data(rawdata, rawoffsets, ::Type{_KM3NETDAQEventHeader}, ::Type{J}) where {T, J <: UnROOT.JaggType}
+function UnROOT.interped_data(rawdata, rawoffsets, ::Type{_KM3NETDAQEventHeader}, ::Type{J}, ::Bool) where {T, J <: UnROOT.JaggType}
     UnROOT.splitup(rawdata, rawoffsets, _KM3NETDAQEventHeader, jagged=false)
 end

--- a/src/iteration.jl
+++ b/src/iteration.jl
@@ -55,11 +55,8 @@ function basketarray(f::ROOTFile, branch, ithbasket, inplace::Bool=false)
 
     rawdata, rawoffsets = readbasket(f, branch, ithbasket)
     T, J = auto_T_JaggT(f, branch; customstructs=f.customstructs)
-    if inplace
-        return interped_data(rawdata, rawoffsets, T, J, true), Ref(rawdata)
-    else
-        return interped_data(rawdata, rawoffsets, T, J)
-    end
+    data = interped_data(rawdata, rawoffsets, T, J, inplace)
+    return inplace ? (data, Ref(rawdata)) : data
 end
 
 """

--- a/src/root.jl
+++ b/src/root.jl
@@ -218,7 +218,7 @@ method of this function with specific `T` and `J`. See `TLorentzVector` example.
 """
 function interped_data(rawdata, rawoffsets, ::Type{Bool}, ::Type{Nojagg}, inplace::Bool=false)
     # specialized case to get Vector{Bool} instead of BitVector
-    return map(ntoh,reinterpret(Bool, rawdata))
+    return inplace ? _interp_inplace(Bool, rawdata) : map(ntoh,reinterpret(Bool, rawdata))
 end
 
 function interped_data(rawdata, rawoffsets, ::Type{T}, ::Type{J}, inplace::Bool=false) where {T, J<:JaggType}


### PR DESCRIPTION
Resurrection of https://github.com/tamasgal/UnROOT.jl/pull/101 (which means some copy-pasting from @Moelf ;) ). Basically, we add a `inplace::Bool` to `interped_data` which toggles between doing `ntoh.(reinterpret(...))` (copy) or an inplace-variant, both returning the same type which means it's still type stable.

But with a small modification, `basketarray()`'s return type depends on the boolean. Probably this can be fixed with a barrier function to discard  the `Ref{UInt8[]}` if called with `inplace=false` (the default.

Unit tests all pass.

```julia
julia> using UnROOT

julia> const t = LazyTree(ROOTFile("uncompressed_Run2012BC_DoubleMuParked_Muons.root"),"Events");

julia> function bar(t)
           for evt in t
               _ = evt.Muon_pt
           end
           nothing
       end
```

### before
```julia
julia> @btime sum(t.nMuon) seconds=10
  204.417 ms (6078 allocations: 469.98 MiB)
0x0000000008e67ad8

julia> @btime bar(t) seconds=10
  712.140 ms (14304 allocations: 1.82 GiB)
```

### after

```julia
julia> @btime sum(t.nMuon) seconds=10
  205.316 ms (6780 allocations: 235.24 MiB)
0x0000000008e67ad8

julia> @btime bar(t) seconds=10
  725.626 ms (16241 allocations: 1.26 GiB)
```

Performance is pretty much the same but with less total allocated memory. If I profile `bar(t)` I see there's a materialization. I thought this should be in place??

![image](https://user-images.githubusercontent.com/5760027/133875328-2fef9e25-0083-4603-8047-79ca750b9dbc.png)
