### PR TITLE
Add `view` of LazyTree

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@
 [![Dev](https://img.shields.io/badge/docs-dev-blue.svg)](https://juliahep.github.io/UnROOT.jl/dev)
 [![Build Status](https://github.com/JuliaHEP/UnROOT.jl/workflows/CI/badge.svg)](https://github.com/JuliaHEP/UnROOT.jl/actions)
 [![Codecov](https://codecov.io/gh/JuliaHEP/UnROOT.jl/branch/master/graph/badge.svg)](https://codecov.io/gh/JuliaHEP/UnROOT.jl)
+[![status](https://joss.theoj.org/papers/bab42b0c60f9dc7ef3b8d6460bc7229c/status.svg)](https://joss.theoj.org/papers/bab42b0c60f9dc7ef3b8d6460bc7229c)
 
 UnROOT.jl is a reader for the [CERN ROOT](https://root.cern) file format
 written entirely in Julia, without any dependence on ROOT or Python.

--- a/src/iteration.jl
+++ b/src/iteration.jl
@@ -219,6 +219,8 @@ function Base.getindex(lt::LazyTree, rang)
     return LazyTree(TypedTables.Table(NamedTuple{bnames}(branches)))
 end
 
+Base.view(lt::LazyTree, idx) = LazyTree(@view innertable(lt)[idx])
+
 # a specific event
 Base.getindex(lt::LazyTree, ::typeof(!), s::Symbol) = lt[:, s]
 Base.getindex(lt::LazyTree, ::Colon, s::Symbol) = getproperty(innertable(lt), s) # the real deal

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -310,8 +310,8 @@ end
     alloc2 = @allocated v = @view data[3:90]
     v = @view data[3:80]
     @test alloc2 < alloc1/100
-    @static if VERSION > v"1.7"
-        @test alloc < 50
+    @static if VERSION >= v"1.8"
+        @test alloc2 < 50
     end
     @test all(v.int32_array .== data.int32_array[3:80])
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -304,10 +304,13 @@ end
 
 @testset "View" begin
     data = LazyTree(joinpath(SAMPLES_DIR, "tree_with_jagged_array.root"), "t1")
+    data[1:2]
     @view data[1:2]
-    alloc = @allocated v = @view data[3:80]
+    alloc1 = @allocated v = data[3:90]
+    alloc2 = @allocated v = @view data[3:90]
     v = @view data[3:80]
-    @static if VERSION >= v"1.7"
+    @test alloc2 < alloc1/100
+    @static if VERSION > v"1.7"
         @test alloc < 50
     end
     @test all(v.int32_array .== data.int32_array[3:80])

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -302,6 +302,21 @@ end
     close(rootfile)
 end
 
+@testset "View" begin
+    data = LazyTree(joinpath(SAMPLES_DIR, "tree_with_jagged_array.root"), "t1")
+    @view data[1:2]
+    alloc = @allocated v = @view data[3:80]
+    v = @view data[3:80]
+    @static if VERSION >= v"1.7"
+        @test alloc < 50
+    end
+    @test all(v.int32_array .== data.int32_array[3:80])
+
+    v2 = @view data[[1,3,5]]
+    @test v2[1].int32_array == data[1].int32_array
+    @test v2[2].int32_array == data[3].int32_array
+end
+
 @testset "Doubly jagged branches" begin
     rootfile = ROOTFile(joinpath(SAMPLES_DIR, "tree_with_doubly_jagged.root"))
     vvi = [[[2], [3, 5]], [[7, 9, 11], [13]], [[17], [19], []], [], [[]]]


### PR DESCRIPTION
if `tf` is a `LazyTree`:
1. `tf[scalar]` gives you `LazyEvent`
2. `tf[AbstractVector]` is always eager, will materialize the events (making disk I/O)
3. `@view tf[AbstractVector]` is lazy <--- this PR makes this work

before this PR, `@view` would give a` SubArray` with `eltype == LazyEvent`, which isn't ideal, now it gives you a proper `LazyTree` table still, with minimal allocation thanks to `view`