### PR TITLE
Reading of c-arrays + more customstructs

### DIFF
--- a/src/UnROOT.jl
+++ b/src/UnROOT.jl
@@ -3,6 +3,7 @@ module UnROOT
 using LazyArrays
 import Mmap: mmap
 export ROOTFile, LazyBranch, LazyTree
+#export FixSizeArray, FixSizeMatrix, FixSizeVector  # would make it more readable in printed tables but not necessary
 
 import Base: close, keys, get, getindex, getproperty, show, length, iterate, position, ntoh, reinterpret
 ntoh(b::Bool) = b

--- a/src/iteration.jl
+++ b/src/iteration.jl
@@ -23,9 +23,9 @@ end
 
 function array(f::ROOTFile, branch; raw=false)
     ismissing(branch) && error("No branch found at $path")
-    # (!raw && length(branch.fLeaves.elements) > 1) && error(
-    #     "Branches with multiple leaves are not supported yet. Try reading with `array(...; raw=true)`.",
-    # )
+    !raw && (!haskey(f.customstructs, branch.fName) && length(branch.fLeaves.elements) > 1) && error(
+        "Branches with multiple leaves are not supported yet. Try reading with `array(...; raw=true)` or by including this branch into `customstructs`.",
+    )
 
     rawdata, rawoffsets = readbranchraw(f, branch)
     if raw
@@ -49,9 +49,9 @@ function basketarray(f::ROOTFile, path::AbstractString, ithbasket)
 end
 function basketarray(f::ROOTFile, branch, ithbasket)
     ismissing(branch) && error("No branch found at $path")
-    # length(branch.fLeaves.elements) > 1 && error(
-    #     "Branches with multiple leaves are not supported yet. Try reading with `array(...; raw=true)`.",
-    # )
+    (!haskey(f.customstructs, branch.fName) && length(branch.fLeaves.elements) > 1) && error(
+        "Branches with multiple leaves are not supported yet. Try reading with `array(...; raw=true)` or by including this branch into `customstructs`.",
+    )
 
     rawdata, rawoffsets = readbasket(f, branch, ithbasket)
     T, J = auto_T_JaggT(f, branch; customstructs=f.customstructs)

--- a/src/iteration.jl
+++ b/src/iteration.jl
@@ -23,9 +23,9 @@ end
 
 function array(f::ROOTFile, branch; raw=false)
     ismissing(branch) && error("No branch found at $path")
-    (!raw && length(branch.fLeaves.elements) > 1) && error(
-        "Branches with multiple leaves are not supported yet. Try reading with `array(...; raw=true)`.",
-    )
+    # (!raw && length(branch.fLeaves.elements) > 1) && error(
+    #     "Branches with multiple leaves are not supported yet. Try reading with `array(...; raw=true)`.",
+    # )
 
     rawdata, rawoffsets = readbranchraw(f, branch)
     if raw
@@ -49,9 +49,9 @@ function basketarray(f::ROOTFile, path::AbstractString, ithbasket)
 end
 function basketarray(f::ROOTFile, branch, ithbasket)
     ismissing(branch) && error("No branch found at $path")
-    length(branch.fLeaves.elements) > 1 && error(
-        "Branches with multiple leaves are not supported yet. Try reading with `array(...; raw=true)`.",
-    )
+    # length(branch.fLeaves.elements) > 1 && error(
+    #     "Branches with multiple leaves are not supported yet. Try reading with `array(...; raw=true)`.",
+    # )
 
     rawdata, rawoffsets = readbasket(f, branch, ithbasket)
     T, J = auto_T_JaggT(f, branch; customstructs=f.customstructs)

--- a/src/root.jl
+++ b/src/root.jl
@@ -318,8 +318,8 @@ function auto_T_JaggT(f::ROOTFile, branch; customstructs::Dict{String, Type})
     leaf = first(branch.fLeaves.elements)
     _type = Nothing
     _jaggtype = JaggType(f, branch, leaf)
-    if hasproperty(branch, :fClassName) || haskey(customstructs, branch.fTitle)
-        classname = hasproperty(branch, :fClassName) ? branch.fClassName : branch.fTitle  # the C++ class name, such as "vector<int>" if C++-class
+    if hasproperty(branch, :fClassName) || haskey(customstructs, branch.fName)
+        classname = hasproperty(branch, :fClassName) ? branch.fClassName : branch.fName  # the C++ class name, such as "vector<int>" if C++-class
         parentname = hasproperty(branch, :fParentName) ? branch.fParentName : nothing  # assuming it has a parent ;)
         try
             # this will call a customize routine if defined by user

--- a/src/root.jl
+++ b/src/root.jl
@@ -318,9 +318,9 @@ function auto_T_JaggT(f::ROOTFile, branch; customstructs::Dict{String, Type})
     leaf = first(branch.fLeaves.elements)
     _type = Nothing
     _jaggtype = JaggType(f, branch, leaf)
-    if hasproperty(branch, :fClassName)
-        classname = branch.fClassName # the C++ class name, such as "vector<int>"
-        parentname = branch.fParentName  # assuming it has a parent ;)
+    if hasproperty(branch, :fClassName) || haskey(customstructs, branch.fTitle)
+        classname = hasproperty(branch, :fClassName) ? branch.fClassName : branch.fTitle  # the C++ class name, such as "vector<int>" if C++-class
+        parentname = hasproperty(branch, :fParentName) ? branch.fParentName : nothing  # assuming it has a parent ;)
         try
             # this will call a customize routine if defined by user
             # see custom.jl
@@ -391,8 +391,6 @@ function auto_T_JaggT(f::ROOTFile, branch; customstructs::Dict{String, Type})
                 _type = Vector{_type}
             end
         end
-    elseif haskey(customstructs, branch.fTitle)
-        return customstructs[branch.fTitle], _jaggtype
     else
         _type = primitivetype(leaf)
         if leaf.fLen > 1 # treat NTuple as Nojagg since size is static

--- a/src/root.jl
+++ b/src/root.jl
@@ -394,7 +394,8 @@ function auto_T_JaggT(f::ROOTFile, branch; customstructs::Dict{String, Type})
     else
         _type = primitivetype(leaf)
         if leaf.fLen > 1 # treat NTuple as Nojagg since size is static
-            _type = FixLenVector{Int(leaf.fLen), _type}
+            dims = LeafDims(leaf)
+            _type = FixSizeArray{Tuple{Int.(dims)...}, _type, length(dims)}
             return _type, Nojagg
         end
         _type = _jaggtype === Nojagg ? _type : Vector{_type}

--- a/src/root.jl
+++ b/src/root.jl
@@ -391,6 +391,8 @@ function auto_T_JaggT(f::ROOTFile, branch; customstructs::Dict{String, Type})
                 _type = Vector{_type}
             end
         end
+    elseif haskey(customstructs, branch.fTitle)
+        return customstructs[branch.fTitle], _jaggtype
     else
         _type = primitivetype(leaf)
         if leaf.fLen > 1 # treat NTuple as Nojagg since size is static

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -105,4 +105,10 @@ function samplefile(filename::AbstractString)
     return ROOTFile(normpath(joinpath(@__DIR__, "../test/samples", filename)))
 end
 
-LeafDims(leaf) = parse.(Int,split(strip(match(r"\[.*\]",leaf.fTitle).match,['[',']']),"]["))
+function LeafDims(leaf)
+    try
+        parse.(Int,split(strip(match(r"\[.*\]",leaf.fTitle).match,['[',']']),"]["))
+    catch
+        leaf.fLen
+    end
+end

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -104,3 +104,5 @@ end
 function samplefile(filename::AbstractString)
     return ROOTFile(normpath(joinpath(@__DIR__, "../test/samples", filename)))
 end
+
+LeafDims(leaf) = parse.(Int,split(strip(match(r"\[.*\]",leaf.fTitle).match,['[',']']),"]["))


### PR DESCRIPTION
After prior discussion in #165 and #166 respectively I decided to put a little bit of effort into extending it to fix #9 finally.

For that I simply enhanced the customstruct to an arbitrary dimensional `FixSizeArray` and parse the fLeaf.fTitle for the decomposition. Everything else works as expected.

Two caveats:
  1. Since all of it relies on wrapping the `StaticArrays.SArray` struct nicely we are also limited to there specifications. With the current implementation of the struct `Base.sizeof()` does not work out of the box due to a missing 4.th parameter in the SArray-type. (see: https://github.com/briederer/UnROOT.jl/blob/3785a042a9cd9855e5f0b9ee18e3b89448bb15d3/src/custom.jl#L49-L53). This means we either add an (for this purpose) unnecessary parameter to the struct or we simply overwrite the `Base.sizeof` method as is done here.
  2. I've also added (like it is usually done in Julia) aliases for `FixSizeVector` and `FixSizeMatrix` to improve readability in the output. However due to some restrictions (see  JuliaLang/julia#40448) the aliases would only be seen for the User if the additional types are exported. But this is not my choice :wink:

Closes #9