### PR TITLE
reduce ambiguity to 0

### DIFF
--- a/docs/src/advanced/custom_branch.md
+++ b/docs/src/advanced/custom_branch.md
@@ -24,7 +24,8 @@ function UnROOT.interped_data(rawdata, rawoffsets, ::Type{LVF64}, ::Type{J}) whe
     ]
 end
 
-function Base.reinterpret(::Type{LVF64}, v::AbstractVector{UInt8}) where T
+# VorView is defined in the `src/custom.jl`
+function Base.reinterpret(::Type{LVF64}, v::VorView) where T
     # x,y,z,t in ROOT
     v4 = ntoh.(reinterpret(Float64, v[1+32:end]))
     # t,x,y,z in LorentzVectors.jl

--- a/src/custom.jl
+++ b/src/custom.jl
@@ -42,7 +42,10 @@ Base.eltype(x::FixLenVector) = eltype(x.vec)
 Base.iterate(x::FixLenVector) = iterate(x.vec)
 Base.iterate(x::FixLenVector, n) = iterate(x.vec, n)
 Base.getindex(x::FixLenVector, n) = getindex(x.vec, n)
-function Base.reinterpret(::Type{FixLenVector{N, T}}, v::AbstractVector{UInt8}) where {N, T}
+
+const VorView = Union{Vector{UInt8}, SubArray{UInt8, 1, Vector{UInt8}, Tuple{UnitRange{Int64}}, true}}
+
+function Base.reinterpret(::Type{FixLenVector{N, T}}, v::VorView) where {N, T}
     vs = reinterpret(T, v)
     @. vs = ntoh(vs)
     FixLenVector(SVector{N, T}(vs))
@@ -57,7 +60,7 @@ end
 # TLorentzVector
 const LVF64 = LorentzVector{Float64}
 Base.show(io::IO, lv::LorentzVector) = print(io, "LV(x=$(lv.x), y=$(lv.y), z=$(lv.z), t=$(lv.t))")
-function Base.reinterpret(::Type{LVF64}, v::AbstractVector{UInt8}) where T
+function Base.reinterpret(::Type{LVF64}, v::VorView)
     # first 32 bytes are TObject header we don't care
     # x,y,z,t in ROOT
     v4 = (reinterpret(Float64, @view v[1+32:end]))

--- a/src/iteration.jl
+++ b/src/iteration.jl
@@ -234,7 +234,8 @@ Base.getindex(lt::LazyTree, ::Colon, s::Int) = getproperty(lt, propertynames(lt)
 Base.getindex(lt::LazyTree, ::Colon, ss) = LazyTree(NamedTuple(propertynames(lt)[s]=>lt[:, s] for s in ss))
 Base.getindex(lt::LazyTree, row::Int, col::Symbol) = lt[:, col][row]
 Base.getindex(lt::LazyTree, rows::UnitRange, col::Symbol) = lt[:, col][rows]
-Base.getindex(lt::LazyTree, row, ::Colon) = lt[row]
+Base.getindex(lt::LazyTree, row::Int, ::Colon) = lt[row]
+Base.getindex(lt::LazyTree, row::AbstractVector, ::Colon) = lt[row]
 Base.getindex(lt::LazyTree, ::Colon) = lt[1:end]
 
 # allow enumerate() to be chunkable (eg with Threads.@threads)
@@ -258,8 +259,8 @@ function LazyArrays.Vcat(ts::LazyTree...)
 end
 Base.vcat(ts::LazyTree...) = Vcat(ts...)
 Base.reduce(::typeof(vcat), ts::AbstractVector{<:LazyTree}) = Vcat((ts)...)
-Base.mapreduce(f::Function, ::typeof(vcat), ts::AbstractVector{<:LazyTree}) = Vcat(f.(ts)...)
-Base.mapreduce(f::Function, ::typeof(Vcat), ts::AbstractVector{<:LazyTree}) = Vcat(f.(ts)...)
+Base.mapreduce(f, ::typeof(vcat), ts::Vector{<:LazyTree}) = Vcat(f.(ts)...)
+Base.mapreduce(f, ::typeof(Vcat), ts::Vector{<:LazyTree}) = Vcat(f.(ts)...)
 
 function getbranchnamesrecursive(obj)
     out = Vector{String}()

--- a/src/root.jl
+++ b/src/root.jl
@@ -202,7 +202,7 @@ function Base.getindex(t::TTree, s::Vector{T}) where {T<:AbstractString}
     [t[n] for n in s]
 end
 
-reinterpret(vt::Type{Vector{T}}, data::AbstractVector{UInt8}) where T <: Union{AbstractFloat, Integer} = reinterpret(T, data)
+reinterpret(vt::Type{Vector{T}}, data::Vector{UInt8}) where T <: Union{AbstractFloat, Integer} = reinterpret(T, data)
 
 """
     interped_data(rawdata, rawoffsets, ::Type{T}, ::Type{J}) where {T, J<:JaggType}


### PR DESCRIPTION
## Before
```julia
julia> Test.detect_ambiguities(UnROOT)
10-element Vector{Tuple{Method, Method}}:
 (reinterpret(vt::Type{Vector{T}}, data::AbstractVector{UInt8}) where T<:Union{AbstractFloat, Integer} in UnROOT at /home/akako/Documents/github/dotFiles/homedir/.julia/dev/UnROOT/src/root.jl:205, reinterpret(::Type{T}, a::Base.ReinterpretArray{T, N, S, A, false} where {T, N, S, A<:AbstractArray{S, N}}) where T in Base at reinterpretarray.jl:137)
 (mapreduce(f, op, a::StaticArraysCore.StaticArray, b::StaticArraysCore.StaticArray...; dims, init) in StaticArrays at /home/akako/.julia/packages/StaticArrays/atiPw/src/mapreduce.jl:109, mapreduce(f::Function, ::UnionAll, ts::AbstractVector{<:LazyTree}) in UnROOT at /home/akako/Documents/github/dotFiles/homedir/.julia/dev/UnROOT/src/iteration.jl:262)
 (mapreduce(f, op, a::StaticArraysCore.StaticArray, b::StaticArraysCore.StaticArray...; dims, init) in StaticArrays at /home/akako/.julia/packages/StaticArrays/atiPw/src/mapreduce.jl:109, mapreduce(f::Function, ::typeof(vcat), ts::AbstractVector{<:LazyTree}) in UnROOT at /home/akako/Documents/github/dotFiles/homedir/.julia/dev/UnROOT/src/iteration.jl:261)
 (reinterpret(::Type, A::SparseArrays.AbstractSparseArray) in SparseArrays at /home/akako/Documents/github/dotFiles/homedir/.julia/juliaup/julia-1.8.1+0.x64/share/julia/stdlib/v1.8/SparseArrays/src/abstractsparse.jl:69, reinterpret(::Type{LorentzVectors.LorentzVector{Float64}}, v::AbstractVector{UInt8}) where T in UnROOT at /home/akako/Documents/github/dotFiles/homedir/.julia/dev/UnROOT/src/custom.jl:60)
 (reinterpret(::Type, A::SparseArrays.AbstractSparseArray) in SparseArrays at /home/akako/Documents/github/dotFiles/homedir/.julia/juliaup/julia-1.8.1+0.x64/share/julia/stdlib/v1.8/SparseArrays/src/abstractsparse.jl:69, reinterpret(::Type{UnROOT.FixLenVector{N, T}}, v::AbstractVector{UInt8}) where {N, T} in UnROOT at /home/akako/Documents/github/dotFiles/homedir/.julia/dev/UnROOT/src/custom.jl:45)
 (reinterpret(::Type, A::SparseArrays.AbstractSparseArray) in SparseArrays at /home/akako/Documents/github/dotFiles/homedir/.julia/juliaup/julia-1.8.1+0.x64/share/julia/stdlib/v1.8/SparseArrays/src/abstractsparse.jl:69, reinterpret(vt::Type{Vector{T}}, data::AbstractVector{UInt8}) where T<:Union{AbstractFloat, Integer} in UnROOT at /home/akako/Documents/github/dotFiles/homedir/.julia/dev/UnROOT/src/root.jl:205)
 (getindex(lt::LazyTree, ::Colon, ss) in UnROOT at /home/akako/Documents/github/dotFiles/homedir/.julia/dev/UnROOT/src/iteration.jl:234, getindex(lt::LazyTree, row, ::Colon) in UnROOT at /home/akako/Documents/github/dotFiles/homedir/.julia/dev/UnROOT/src/iteration.jl:237)
 (reinterpret(::Type{LorentzVectors.LorentzVector{Float64}}, v::AbstractVector{UInt8}) where T in UnROOT at /home/akako/Documents/github/dotFiles/homedir/.julia/dev/UnROOT/src/custom.jl:60, reinterpret(::Type{T}, a::Base.ReinterpretArray{T, N, S, A, false} where {T, N, S, A<:AbstractArray{S, N}}) where T in Base at reinterpretarray.jl:137)
 (reinterpret(::Type{UnROOT.FixLenVector{N, T}}, v::AbstractVector{UInt8}) where {N, T} in UnROOT at /home/akako/Documents/github/dotFiles/homedir/.julia/dev/UnROOT/src/custom.jl:45, reinterpret(::Type{T}, a::Base.ReinterpretArray{T, N, S, A, false} where {T, N, S, A<:AbstractArray{S, N}}) where T in Base at reinterpretarray.jl:137)
 (getindex(lt::LazyTree, ::typeof(!), s) in UnROOT at /home/akako/Documents/github/dotFiles/homedir/.julia/dev/UnROOT/src/iteration.jl:231, getindex(lt::LazyTree, row, ::Colon) in UnROOT at /home/akako/Documents/github/dotFiles/homedir/.julia/dev/UnROOT/src/iteration.jl:237)
```