### PR TITLE
Better browsing

### DIFF
--- a/src/displays.jl
+++ b/src/displays.jl
@@ -46,6 +46,9 @@ function children(t::TTree)
         return ks
     end
 end
+children(t::Union{TTree, TBranchElement}) = t.fBranches
+Base.show(io::IO, ::MIME"text/plain", b::Union{TTree, TBranchElement}) = print_tree(io, b)
+printnode(io::IO, t::TBranchElement) = print(io, "$(t.fName)")
 printnode(io::IO, t::TTree) = print(io, "$(t.fName) (TTree)")
 printnode(io::IO, f::ROOTFile) = print(io, f.filename)
 printnode(io::IO, f::ROOTDirectory) = print(io, "$(f.name) (TDirectory)")

--- a/src/displays.jl
+++ b/src/displays.jl
@@ -47,7 +47,13 @@ function children(t::TTree)
     end
 end
 children(t::Union{TTree, TBranchElement}) = t.fBranches
-Base.show(io::IO, ::MIME"text/plain", b::Union{TTree, TBranchElement}) = print_tree(io, b)
+function Base.show(io::IO, ::MIME"text/plain", b::Union{TTree, TBranchElement})
+    if isempty(b.fBranches)
+        print(io, b)
+    else
+        print_tree(io, b)
+    end
+end
 printnode(io::IO, t::TBranchElement) = print(io, "$(t.fName)")
 printnode(io::IO, t::TTree) = print(io, "$(t.fName) (TTree)")
 printnode(io::IO, f::ROOTFile) = print(io, f.filename)

--- a/src/iteration.jl
+++ b/src/iteration.jl
@@ -404,7 +404,7 @@ function LazyTree(f::ROOTFile, tree::TTree, s, branches)
             replace!(tail, "fCoordinates" => "")
             norm_name = join([head; join(tail)], "_")
         end
-        d[Symbol(norm_name)] = f["$s/$b"]
+        d[Symbol(norm_name)] = LazyBranch(f, f["$s/$b"])
     end
     return LazyTree(NamedTuple{Tuple(keys(d))}(values(d)))
 end

--- a/src/iteration.jl
+++ b/src/iteration.jl
@@ -122,6 +122,7 @@ mutable struct LazyBranch{T,J,B} <: AbstractVector{T}
                                         [0:-1 for _ in 1:Threads.nthreads()])
     end
 end
+LazyBranch(f::ROOTFile, s::AbstractString) = LazyBranch(f, _getindex(f, s))
 basketarray(lb::LazyBranch, ithbasket) = basketarray(lb.f, lb.b, ithbasket)
 basketarray_iter(lb::LazyBranch) = basketarray_iter(lb.f, lb.b)
 

--- a/src/iteration.jl
+++ b/src/iteration.jl
@@ -405,7 +405,7 @@ function LazyTree(f::ROOTFile, tree::TTree, s, branches)
             replace!(tail, "fCoordinates" => "")
             norm_name = join([head; join(tail)], "_")
         end
-        d[Symbol(norm_name)] = LazyBranch(f, f["$s/$b"])
+        d[Symbol(norm_name)] = LazyBranch(f, "$s/$b")
     end
     return LazyTree(NamedTuple{Tuple(keys(d))}(values(d)))
 end

--- a/src/root.jl
+++ b/src/root.jl
@@ -135,15 +135,7 @@ end
 
 
 function Base.getindex(f::ROOTFile, s::AbstractString)
-    S = _getindex(f, s)
-    if S isa Union{TBranch, TBranchElement}
-        try # if we can't construct LazyBranch, just give up (maybe due to custom class)
-            return LazyBranch(f, S)
-        catch
-            @warn "Can't automatically create LazyBranch for branch $s. Returning a branch object"
-        end
-    end
-    S
+    _getindex(f, s)
 end
 
 @memoize LRU(maxsize = 2000) function _getindex(f::ROOTFile, s)

--- a/src/root.jl
+++ b/src/root.jl
@@ -394,10 +394,6 @@ function auto_T_JaggT(f::ROOTFile, branch; customstructs::Dict{String, Type})
         else
             leaftype = _normalize_ftype(leaf.fType)
             _type = get(_leaftypeconstlookup, leaftype, nothing)
-            if isnothing(_type)
-                @error "Cannot interpret type."
-                return nothing
-            end
             if branch.fType == Const.kSubbranchSTLCollection
                 _type = Vector{_type}
             end

--- a/src/streamers.jl
+++ b/src/streamers.jl
@@ -31,6 +31,7 @@ struct TStreamerInfo{T}
 end
 
 function unpack(io, tkey::TKey, refs::Dict{Int32, Any}, T::Type{TStreamerInfo})
+    @debug "Unpacking: $(tkey)"
     preamble = Preamble(io, T)
     fName, fTitle = nametitle(io)
     fCheckSum = readtype(io, UInt32)
@@ -307,6 +308,7 @@ end
 Base.getindex(obj::TObjArray, index) = obj.elements[index]
 
 function unpack(io, tkey::TKey, refs::Dict{Int32, Any}, T::Type{TObjArray})
+    @debug "Unpacking: $(tkey)"
     preamble = Preamble(io, T)
     skiptobj(io)
     name = readtype(io, String)

--- a/src/streamers.jl
+++ b/src/streamers.jl
@@ -306,6 +306,8 @@ struct TObjArray
     elements
 end
 Base.getindex(obj::TObjArray, index) = obj.elements[index]
+Base.length(a::TObjArray) = length(a.elements)
+Base.iterate(a::TObjArray, state=1) = state > length(a) ? nothing : (a.elements[state], state+1)
 
 function unpack(io, tkey::TKey, refs::Dict{Int32, Any}, T::Type{TObjArray})
     @debug "Unpacking: $(tkey)"

--- a/src/types.jl
+++ b/src/types.jl
@@ -151,7 +151,8 @@ function decompress_datastreambytes(compbytes, tkey)
         compression_header = unpack(io, CompressionHeader)
         cname, _, compbytes, uncompbytes = unpack(compression_header)
         rawbytes = read(io, compbytes)
-        @debug cname
+        @debug "Compression type: $(cname)"
+        @debug "Compressed/uncompressed size in bytes: $(compbytes) / $(uncompbytes)"
 
         if cname == "L4"
             # skip checksum which is 8 bytes


### PR DESCRIPTION
This will break a few things since `f["what/ever"]` will now always return the object which sits at that "position" but the navigation is much easier.

Before this PR, `UnROOT` choked on branches which could not be interpreted so that the user's only option to explore the structure was to use `.fBranches` etc. and dig into ROOT internals.

Now, if a `TTree` or `TBranchElement` is returned by `getindex()`, the branches are listed:

```julia
julia> using UnROOT
[ Info: Precompiling UnROOT [3cd96dde-e98d-4713-81e9-a4a1b0235ce9]

julia> f = ROOTFile("mcv7.2.gsg_muon-CC_1-100GeV.km3sim.jterbr00011156.jorcarec.aanet.2591.root")
ROOTFile with 4 entries and 32 streamers.
mcv7.2.gsg_muon-CC_1-100GeV.km3sim.jterbr00011156.jorcarec.aanet.2591.root
├─ E (TTree)
│  └─ "Evt"
├─ KM3NET_SUMMARYSLICE (TTree)
│  └─ "KM3NET_SUMMARYSLICE"
├─ Head (Head)
└─ META (TDirectory)
   ├─ JMeta (TNamed)
   ├─ JMeta (TNamed)
   ├─ JMeta (TNamed)
   ├─ JMeta (TNamed)
   ├─ JMeta (TNamed)
   ├─ JMeta (TNamed)
   ├─ JMeta (TNamed)
   ├─ JMeta (TNamed)
   ├─ JConvertEvt (TNamed)
   ├─ JMuonEnergy (TNamed)
   ├─ JMuonStart (TNamed)
   ├─ JMuonStart (TNamed)
   ├─ JMuonGandalf (TNamed)
   ├─ JMuonSimplex (TNamed)
   ├─ JMuonPrefit (TNamed)
   └─ JTriggerEfficiency (TNamed)


julia> f["E"]
E (TTree)
└─ "Evt"


julia> f["E/Evt"]
Evt
├─ AAObject
│  ├─ TObject
│  │  ├─ fUniqueID
│  │  └─ fBits
│  ├─ usr
│  ├─ usr_names
│  └─ any
├─ id
├─ det_id
├─ mc_id
├─ run_id
├─ mc_run_id
├─ frame_index
├─ trigger_mask
├─ trigger_counter
├─ overlays
├─ t
│  ├─ t.fSec
│  └─ t.fNanoSec
├─ hits
│  ├─ hits.fUniqueID
```