### PR TITLE
implement Table.partition and test Arrow round-trips for LazyTree

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -52,6 +52,8 @@ MD5 = "6ac74813-4b46-53a4-afec-0b5dc9d7885c"
 Pkg = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 ThreadsX = "ac1d9e8a-700a-412c-b207-f0111f4b6c0d"
+Arrow = "69666777-d1a9-59fb-9406-91d4454c9d45"
+DataFrames = "a93c6f00-e57d-5684-b7b6-d8193f3e46c0"
 
 [targets]
-test = ["Test", "Pkg", "ThreadsX", "MD5", "InteractiveUtils"]
+test = ["Test", "Pkg", "ThreadsX", "MD5", "InteractiveUtils", "Arrow", "DataFrames"]

--- a/src/RNTuple/displays.jl
+++ b/src/RNTuple/displays.jl
@@ -49,7 +49,7 @@ function Base.summary(io::IO, rf::RNTupleField{R, F, O, E}) where {R, F, O, E}
 end
 
 function Base.show(io::IO, rn::RNTuple) 
-    println(io, "UnROOT.RNTuple:")
+    println(io, "UnROOT.RNTuple with $(_length(rn)) rows, $(length(rn.schema)) fields, and metadata:")
     println(io, "  header: ")
     println(io, "    name: \"$(rn.header.name)\"")
     println(io, "    ntuple_description: \"$(rn.header.ntuple_description)\"")

--- a/src/RNTuple/footer.jl
+++ b/src/RNTuple/footer.jl
@@ -56,7 +56,7 @@ end
 @with_kw struct RNTupleFooter
     feature_flag::UInt64
     header_crc32::UInt32
-    extension_header_links::Vector{EnvLink} # this is a bare list frame for some reason
+    extension_header_links::Vector{EnvLink}
     column_group_records::Vector{ColumnGroupRecord}
     cluster_summaries::Vector{ClusterSummary}
     cluster_group_records::Vector{ClusterGroupRecord}
@@ -65,7 +65,7 @@ end
 function _rntuple_read(io, ::Type{RNTupleFooter})
     feature_flag = read(io, UInt64)
     header_crc32 = read(io, UInt32)
-    extension_header_links = _rntuple_read(io, RNTupleListNoFrame{FieldRecord})
+    extension_header_links = _rntuple_read(io, RNTupleListFrame{FieldRecord})
     column_group_records = _rntuple_read(io, RNTupleListFrame{ColumnGroupRecord})
     cluster_summaries = _rntuple_read(io, RNTupleListFrame{ClusterSummary})
     cluster_group_records = _rntuple_read(io, RNTupleListFrame{ClusterGroupRecord})

--- a/src/RNTuple/highlevel.jl
+++ b/src/RNTuple/highlevel.jl
@@ -26,7 +26,17 @@ end
 Base.length(rf::RNTupleField) = _length(rf.rn)
 Base.size(rf::RNTupleField) = (length(rf), )
 Base.IndexStyle(::RNTupleField) = IndexLinear()
+
 # this is used for Table.partition()
+"""
+The event number range a given cluster covers, in Julia's index
+"""
+function _rntuple_clusterrange(cs::ClusterSummary)
+        first_entry = cs.num_first_entry 
+        n_entries = cs.num_entries
+        return first_entry+1:(first_entry+n_entries)
+end
+
 function _clusterranges(lbs::AbstractVector{<:RNTupleField})
     ranges = map(_rntuple_clusterrange, first(lbs).rn.footer.cluster_summaries)
     return ranges
@@ -91,15 +101,6 @@ function _read_page_list(rn, nth_cluster_group=1)
     return _rntuple_read(IOBuffer(bytes), RNTupleEnvelope{PageLink}).payload
 end
 
-"""
-The event number range a given cluster covers, in Julia's index
-"""
-function _rntuple_clusterrange(cluster)
-        first_entry = cluster.num_first_entry 
-        n_entries = cluster.num_entries
-        return first_entry+1:(first_entry+n_entries)
-end
-
 function _localindex_newcluster!(rf::RNTupleField, idx::Int, tid::Int)
     page_list = _read_page_list(rf.rn, 1)
     summaries = rf.rn.footer.cluster_summaries
@@ -108,7 +109,7 @@ function _localindex_newcluster!(rf::RNTupleField, idx::Int, tid::Int)
         first_entry = cluster.num_first_entry 
         n_entries = cluster.num_entries
         if first_entry + n_entries >= idx
-            br = _rntuple_clusterrange(cluster)
+            br = first_entry+1:(first_entry+n_entries)
             rf.buffers[tid] = read_field(rf.rn.io, rf.field, page_list[cluster_idx])
             rf.buffer_ranges[tid] = br
             return idx - br.start + 1


### PR DESCRIPTION
```julia
julia> f = ROOTFile("./test/samples/RNTuple/test_ntuple_stl_containers.root");

julia> rnt = LazyTree(f, "ntuple")
 Row │ string  vector_int32   array_float      vector_vector_i  vector_string   vector_vector_s  varia ⋯
     │ String  Vector{Int32}  StaticArraysCor  Vector{Vector{I  Vector{String}  Vector{Vector{S  Union ⋯
─────┼──────────────────────────────────────────────────────────────────────────────────────────────────
 1   │ one     [1]            [1.0, 1.0, 1.    Vector{Int32}    ["one"]         [["one"]]        1     ⋯
 2   │ two     [1, 2]         [2.0, 2.0, 2.    Vector{Int32}    ["one", "two"   [["one"], ["t    two   ⋯
 3   │ three   [1, 2, 3]      [3.0, 3.0, 3.    Vector{Int32}    ["one", "two"   [["one"], ["t    three ⋯
 4   │ four    [1, 2, 3, 4]   [4.0, 4.0, 4.    Vector{Int32}    ["one", "two"   [["one"], ["t    4     ⋯
 5   │ five    [1, 2, 3, 4,   [5.0, 5.0, 5.    Vector{Int32}    ["one", "two"   [["one"], ["t    5     ⋯
                                                                                       7 columns omitted


julia> a
"/tmp/jl_Sj6vmtAR0d"

julia> Arrow.write(a, rnt)
"/tmp/jl_Sj6vmtAR0d"

julia> Arrow.Table(a)
Arrow.Table with 5 rows, 13 columns, and schema:
 :string                       String
 :vector_int32                 Vector{Int32} (alias for Array{Int32, 1})
 :array_float                  Vector{Float32} (alias for Array{Float32, 1})
 :vector_vector_int32          Vector{Vector{Int32}} (alias for Array{Array{Int32, 1}, 1})
 :vector_string                Vector{String} (alias for Array{String, 1})
 :vector_vector_string         Vector{Vector{String}} (alias for Array{Array{String, 1}, 1})
 :variant_int32_string         Union{Missing, Int32, String}
 :vector_variant_int64_string  Vector{Union{Missing, Int64, String}} (alias for Array{Union{Missing, Int64, String}, 1})
 :tuple_int32_string           NamedTuple{(:_0, :_1), Tuple{Int32, String}}
 :pair_int32_string            NamedTuple{(:_0, :_1), Tuple{Int32, String}}
 :vector_tuple_int32_string    Vector{NamedTuple{(:_0, :_1), Tuple{Int32, String}}} (alias for Array{NamedTuple{(:_0, :_1), Tuple{Int32, String}}, 1})
 :lorentz_vector               NamedTuple{(:pt, :eta, :phi, :mass), NTuple{4, Float32}}
 :array_lv                     Vector{NamedTuple{(:pt, :eta, :phi, :mass), NTuple{4, Float32}}} (alias for Array{NamedTuple{(:pt, :eta, :phi, :mass), NTuple{4, Float32}}, 1})

julia> DataFrame(Arrow.Table(a))
5×13 DataFrame
 Row │ string  vector_int32          array_float             vector_vector_int32                vector ⋯
     │ String  Array…                Array…                  Array…                             Array… ⋯
─────┼──────────────────────────────────────────────────────────────────────────────────────────────────
   1 │ one     Int32[1]              Float32[1.0, 1.0, 1.0]  Vector{Int32}[[1]]                 ["one" ⋯
   2 │ two     Int32[1, 2]           Float32[2.0, 2.0, 2.0]  Vector{Int32}[[1], [2]]            ["one"
   3 │ three   Int32[1, 2, 3]        Float32[3.0, 3.0, 3.0]  Vector{Int32}[[1], [2], [3]]       ["one"
   4 │ four    Int32[1, 2, 3, 4]     Float32[4.0, 4.0, 4.0]  Vector{Int32}[[1], [2], [3], [4]]  ["one"
   5 │ five    Int32[1, 2, 3, 4, 5]  Float32[5.0, 5.0, 5.0]  Vector{Int32}[[1], [2], [3], [4]…  ["one" ⋯

  ```
