### PR TITLE
Fix streamer lookup

### DIFF
--- a/src/utils.jl
+++ b/src/utils.jl
@@ -58,15 +58,15 @@ struct Offsetjaggjagg  <:JaggType  end
 
 function JaggType(f, branch, leaf)
     # https://github.com/scikit-hep/uproot3/blob/54f5151fb7c686c3a161fbe44b9f299e482f346b/uproot3/interp/auto.py#L144
+    try
+        streamer = streamerfor(f, branch.fClassName).streamer.fElements.elements[branch.fID + 1]
+        (streamer.fSTLtype == Const.kSTLvector) && return Offsetjagg
+    catch
+    end
     (match(r"\[.*\]", leaf.fTitle) !== nothing) && return Nooffsetjagg
     leaf isa TLeafElement && leaf.fLenType==0 && return Offsetjagg
     !hasproperty(branch, :fClassName) && return Nojagg
 
-    try
-        streamer = streamerfor(f, branch.fClassName).streamer.fElements.elements[1]
-        (streamer.fSTLtype == Const.kSTLvector) && return Offsetjagg
-    catch
-    end
 
     return Nojagg
 end

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -58,11 +58,17 @@ struct Offsetjaggjagg  <:JaggType  end
 
 function JaggType(f, branch, leaf)
     # https://github.com/scikit-hep/uproot3/blob/54f5151fb7c686c3a161fbe44b9f299e482f346b/uproot3/interp/auto.py#L144
+
     try
-        streamer = streamerfor(f, branch.fClassName).streamer.fElements.elements[branch.fID + 1]
+        fID = branch.fID
+        if fID == -1 # TODO: unclear what -1 means, for now we treat it as "0"
+            fID = 0
+        end
+        streamer = streamerfor(f, branch.fClassName).streamer.fElements.elements[fID + 1]  # one-based indexing in Julia
         (streamer.fSTLtype == Const.kSTLvector) && return Offsetjagg
     catch
     end
+
     (match(r"\[.*\]", leaf.fTitle) !== nothing) && return Nooffsetjagg
     leaf isa TLeafElement && leaf.fLenType==0 && return Offsetjagg
     !hasproperty(branch, :fClassName) && return Nojagg

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -61,7 +61,14 @@ function JaggType(f, branch, leaf)
 
     try
         fID = branch.fID
-        if fID == -1 # TODO: unclear what -1 means, for now we treat it as "0"
+        # According to ChatGPt: When fID is equal to -1, it means that the
+        # TBranch object has not been registered yet in the TTree's list of
+        # branches. This can happen, for example, when a TBranch object has been
+        # created, but has not been added to a TTree with the TTree::Branch()
+        # method.
+        #
+        # TODO: For now, we force it to be 0 in this case, until someone complains.
+        if fID == -1
             fID = 0
         end
         streamer = streamerfor(f, branch.fClassName).streamer.fElements.elements[fID + 1]  # one-based indexing in Julia


### PR DESCRIPTION
@Moelf I might need a little bit of help here ;) I realised that the streamer lookup is bugged and I also need to change the order of decisions in `JaggType`. I think that streamer information should have precedence over other methods of type-guess, like matching `[*]` in the title etc.

Currently we have a "last-resort" lookup in the streamer list of a class, where we take the first element. This was calling for trouble for custom classes which have multiple fields (with possibly different types). See my revelation at https://github.com/JuliaHEP/UnROOT.jl/issues/226#issuecomment-1469725092

TL;DR: I realised that `fID` is the index of to the streamer of the parent class' streamer list, so this PR is definitely a bug fix.

All the tests pass but two are failing:

```
issues: Error During Test at /Users/tamasgal/Dev/UnROOT.jl/test/runtests.jl:620
  Test threw exception
  Expression: (LazyBranch(rootfile, "Events/Jet_pt"))[:] == Vector{Float32}[[], [27.324587, 24.889547, 20.853024], [], [20.33066], [], []]
  MethodError: Cannot `convert` an object of type Float32 to an object of type Vector{Float32}
  Closest candidates are:
    convert(::Type{T}, ::LinearAlgebra.Factorization) where T<:AbstractArray at ~/.julia/juliaup/julia-1.8.5+0.aarch64.apple.darwin14/share/julia/stdlib/v1.8/LinearAlgebra/src/factorization.jl:58
    convert(::Type{Array{T, N}}, ::SizedArray{S, T, N, N, Array{T, N}}) where {S, T, N} at ~/.julia/packages/StaticArrays/PUoe1/src/SizedArray.jl:88
    convert(::Type{Array{T, N}}, ::SizedArray{S, T, N, M, TData} where {M, TData<:AbstractArray{T, M}}) where {T, S, N} at ~/.julia/packages/StaticArrays/PUoe1/src/SizedArray.jl:82
    ...
  Stacktrace:
    [1] setindex!(A::Vector{Vector{Float32}}, x::Float32, i1::Int64)
      @ Base ./array.jl:966
    [2] _unsafe_copyto!(dest::Vector{Vector{Float32}}, doffs::Int64, src::Vector{Float32}, soffs::Int64, n::Int64)
      @ Base ./array.jl:253
    [3] unsafe_copyto!
      @ ./array.jl:307 [inlined]
    [4] _copyto_impl!
      @ ./array.jl:331 [inlined]
    [5] copyto!
      @ ./array.jl:317 [inlined]
    [6] copyto!
      @ ./array.jl:343 [inlined]
    [7] copyto_axcheck!
      @ ./abstractarray.jl:1127 [inlined]
    [8] Array
      @ ./array.jl:626 [inlined]
    [9] convert
      @ ./array.jl:617 [inlined]
   [10] setindex!(A::Vector{Vector{Vector{Float32}}}, x::Vector{Float32}, i1::Int64)
      @ Base ./array.jl:966
   [11] _localindex_newbasket!(ba::LazyBranch{Vector{Float32}, UnROOT.Nojagg, Vector{Vector{Float32}}}, idx::Int64, tid::Int64)
      @ UnROOT ~/Dev/UnROOT.jl/src/iteration.jl:183
   [12] getindex
      @ ~/Dev/UnROOT.jl/src/iteration.jl:174 [inlined]
   [13] macro expansion
      @ ./multidimensional.jl:903 [inlined]
   [14] macro expansion
      @ ./cartesian.jl:64 [inlined]
   [15] _unsafe_getindex!
      @ ./multidimensional.jl:898 [inlined]
   [16] _unsafe_getindex(#unused#::IndexLinear, A::LazyBranch{Vector{Float32}, UnROOT.Nojagg, Vector{Vector{Float32}}}, I::Base.Slice{Base.OneTo{Int64}})
      @ Base ./multidimensional.jl:889
   [17] _getindex
      @ ./multidimensional.jl:875 [inlined]
   [18] getindex(A::LazyBranch{Vector{Float32}, UnROOT.Nojagg, Vector{Vector{Float32}}}, I::Function)
      @ Base ./abstractarray.jl:1241
   [19] macro expansion
      @ ~/.julia/juliaup/julia-1.8.5+0.aarch64.apple.darwin14/share/julia/stdlib/v1.8/Test/src/Test.jl:464 [inlined]
   [20] macro expansion
      @ ~/Dev/UnROOT.jl/test/runtests.jl:620 [inlined]
   [21] macro expansion
      @ ~/.julia/juliaup/julia-1.8.5+0.aarch64.apple.darwin14/share/julia/stdlib/v1.8/Test/src/Test.jl:1363 [inlined]
   [22] top-level scope
      @ ~/Dev/UnROOT.jl/test/runtests.jl:601
issues: Error During Test at /Users/tamasgal/Dev/UnROOT.jl/test/runtests.jl:600
  Got exception outside of a @test
  MethodError: Cannot `convert` an object of type Float32 to an object of type Vector{Float32}
  Closest candidates are:
    convert(::Type{T}, ::LinearAlgebra.Factorization) where T<:AbstractArray at ~/.julia/juliaup/julia-1.8.5+0.aarch64.apple.darwin14/share/julia/stdlib/v1.8/LinearAlgebra/src/factorization.jl:58
    convert(::Type{Array{T, N}}, ::SizedArray{S, T, N, N, Array{T, N}}) where {S, T, N} at ~/.julia/packages/StaticArrays/PUoe1/src/SizedArray.jl:88
    convert(::Type{Array{T, N}}, ::SizedArray{S, T, N, M, TData} where {M, TData<:AbstractArray{T, M}}) where {T, S, N} at ~/.julia/packages/StaticArrays/PUoe1/src/SizedArray.jl:82
    ...
  Stacktrace:
    [1] setindex!(A::Vector{Vector{Float32}}, x::Float32, i1::Int64)
      @ Base ./array.jl:966
    [2] _unsafe_copyto!(dest::Vector{Vector{Float32}}, doffs::Int64, src::Vector{Float32}, soffs::Int64, n::Int64)
      @ Base ./array.jl:253
    [3] unsafe_copyto!
      @ ./array.jl:307 [inlined]
    [4] _copyto_impl!
      @ ./array.jl:331 [inlined]
    [5] copyto!
      @ ./array.jl:317 [inlined]
    [6] copyto!
      @ ./array.jl:343 [inlined]
    [7] copyto_axcheck!
      @ ./abstractarray.jl:1127 [inlined]
    [8] Array
      @ ./array.jl:626 [inlined]
    [9] convert
      @ ./array.jl:617 [inlined]
   [10] setindex!(A::Vector{Vector{Vector{Float32}}}, x::Vector{Float32}, i1::Int64)
      @ Base ./array.jl:966
   [11] _localindex_newbasket!(ba::LazyBranch{Vector{Float32}, UnROOT.Nojagg, Vector{Vector{Float32}}}, idx::Int64, tid::Int64)
      @ UnROOT ~/Dev/UnROOT.jl/src/iteration.jl:183
   [12] getindex
      @ ~/Dev/UnROOT.jl/src/iteration.jl:174 [inlined]
   [13] _broadcast_getindex
      @ ./broadcast.jl:636 [inlined]
   [14] _getindex
      @ ./broadcast.jl:667 [inlined]
   [15] _broadcast_getindex
      @ ./broadcast.jl:642 [inlined]
   [16] getindex
      @ ./broadcast.jl:597 [inlined]
   [17] macro expansion
      @ ./broadcast.jl:961 [inlined]
   [18] macro expansion
      @ ./simdloop.jl:77 [inlined]
   [19] copyto!
      @ ./broadcast.jl:960 [inlined]
   [20] copyto!
      @ ./broadcast.jl:913 [inlined]
   [21] copy
      @ ./broadcast.jl:885 [inlined]
   [22] materialize(bc::Base.Broadcast.Broadcasted{Base.Broadcast.DefaultArrayStyle{1}, Nothing, typeof(length), Tuple{LazyBranch{Vector{Float32}, UnROOT.Nojagg, Vector{Vector{Float32}}}}})
      @ Base.Broadcast ./broadcast.jl:860
   [23] macro expansion
      @ ~/Dev/UnROOT.jl/test/runtests.jl:626 [inlined]
   [24] macro expansion
      @ ~/.julia/juliaup/julia-1.8.5+0.aarch64.apple.darwin14/share/julia/stdlib/v1.8/Test/src/Test.jl:1363 [inlined]
   [25] top-level scope
      @ ~/Dev/UnROOT.jl/test/runtests.jl:601
   [26] include(fname::String)
      @ Base.MainInclude ./client.jl:476
   [27] top-level scope
      @ none:6
   [28] eval
      @ ./boot.jl:368 [inlined]
   [29] exec_options(opts::Base.JLOptions)
      @ Base ./client.jl:276
   [30] _start()
      @ Base ./client.jl:522
Test Summary: | Pass  Error  Total  Time
issues        |    7      2      9  1.9s
ERROR: LoadError: Some tests did not pass: 7 passed, 0 failed, 2 errored, 0 broken.
in expression starting at /Users/tamasgal/Dev/UnROOT.jl/test/runtests.jl:600
ERROR: Package UnROOT errored during testing
```