### PR TITLE
Custom TObject hook

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "UnROOT"
 uuid = "3cd96dde-e98d-4713-81e9-a4a1b0235ce9"
 authors = ["Tamas Gal", "Jerry Ling", "Johannes Schumann", "Nick Amin"]
-version = "0.10.1"
+version = "0.10.2"
 
 [deps]
 AbstractTrees = "1520ce14-60c1-5f80-bbc7-55ef81b5835c"

--- a/src/bootstrap.jl
+++ b/src/bootstrap.jl
@@ -885,6 +885,25 @@ function TNtuple(io, tkey::TKey, refs)
     tree = TTree(io, tkey, refs; top=false) #embeded tree
 end
 
+function TObjectGeneric(io, tkey::TKey, refs)
+    # pass the correct parser from f!
+    @show tkey
+    io = datastream(io, tkey)
+    preamble = Preamble(io, Missing)
+    @initparse
+    parsefields!(io, fields, TObject)
+    fobj = open("/tmp/head.dat", "w")
+    data = read(io)
+    write(fobj, data)
+    close(fobj)
+
+#    name = readtype(io, String)
+#    title = readtype(io, String)
+#    data = read(io)
+    # @show name, title
+    @show fields
+    @show data
+end
 
 # FIXME preliminary TTree implementation
 function TTree(io, tkey::TKey, refs; top=true)

--- a/src/bootstrap.jl
+++ b/src/bootstrap.jl
@@ -885,24 +885,32 @@ function TNtuple(io, tkey::TKey, refs)
     tree = TTree(io, tkey, refs; top=false) #embeded tree
 end
 
-function TObjectGeneric(io, tkey::TKey, refs)
+"""
+Direct parsing of streamed objects which are not sitting on branches.
+"""
+function parsetobject(io, tkey::TKey, streamer)
     # pass the correct parser from f!
-    @show tkey
     io = datastream(io, tkey)
     preamble = Preamble(io, Missing)
-    @initparse
-    parsefields!(io, fields, TObject)
-    fobj = open("/tmp/head.dat", "w")
-    data = read(io)
-    write(fobj, data)
-    close(fobj)
 
-#    name = readtype(io, String)
-#    title = readtype(io, String)
-#    data = read(io)
-    # @show name, title
-    @show fields
-    @show data
+    @initparse
+
+    # the first entry in the streamer is a TOBject
+    parsefields!(io, fields, TObject)
+
+    # the second (and last) entry is the actual data streamer (we think)
+    s = streamer.streamer.fElements.elements[2]
+    if s.fTypeName == "map<string,string>"
+        skip(io, 3*4)  # unclear what the first 12 bytes are
+        # this gives the number of elements
+        n = readtype(io, Int32)
+        skip(io, 6)  # the usual header stuff?
+        keys = [readtype(io, String) for i ∈ 1:n]
+        skip(io, 6)  # the usual header stuff?
+        values = [readtype(io, String) for i ∈ 1:n]
+        return Dict(zip(keys, values))
+    end
+    error("Unable to parse '$(s.fTypeName)' of '$(tkey.fClassName)'")
 end
 
 # FIXME preliminary TTree implementation

--- a/src/root.jl
+++ b/src/root.jl
@@ -169,10 +169,10 @@ end
         S = streamer(f.fobj, tkey, f.streamers.refs)
         return S
     catch UndefVarError
-        # Try generic TObject parsing
-        return TObjectGeneric(f.fobj, tkey, f.streamers.refs)
     end
-    error("No parsing logic for '$(typename)', please provide a custom implementation.")
+
+    # last resort, try direct parsing
+    parsetobject(f.fobj, tkey, streamerfor(f, typename))
 end
 
 # FIXME unify with above?

--- a/src/root.jl
+++ b/src/root.jl
@@ -162,10 +162,17 @@ end
         return f[first(paths)][join(paths[2:end], "/")]
     end
     tkey = f.directory.keys[findfirst(isequal(s), keys(f))]
-    @debug "Retrieving $s ('$(tkey.fClassName)')"
-    streamer = getfield(@__MODULE__, Symbol(safename(tkey.fClassName)))
-    S = streamer(f.fobj, tkey, f.streamers.refs)
-    return S
+    typename = safename(tkey.fClassName)
+    @debug "Retrieving $s ('$(typename)')"
+    try
+        streamer = getfield(@__MODULE__, Symbol(typename))
+        S = streamer(f.fobj, tkey, f.streamers.refs)
+        return S
+    catch UndefVarError
+        # Try generic TObject parsing
+        return TObjectGeneric(f.fobj, tkey, f.streamers.refs)
+    end
+    error("No parsing logic for '$(typename)', please provide a custom implementation.")
 end
 
 # FIXME unify with above?

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -218,6 +218,17 @@ end
     # close(rootfile)
 end
 
+@testset "Single TObject subclasses" begin
+    f = UnROOT.samplefile("triply_jagged_via_custom_class.root")
+    # map<string,string>
+    head = f["Head"]
+    @test 27 == length(f["Head"])
+    @test " 3.3" == head["DAQ"]
+    @test " CORSIKA 7.640 181111 1211" == head["physics"]
+    @test "MUSIC seawater 02-03  190204  1643" == head["propag"]
+    close(f)
+end
+
 @testset "LazyBranch and LazyTree" begin
     rootfile = ROOTFile(joinpath(SAMPLES_DIR, "tree_with_large_array.root"))
     branch = rootfile["t1"]["int32_array"]


### PR DESCRIPTION
Sometimes, TObject subclassed instances are sitting on the tree and we don't have any mechanism to hook into those. This implementation can probably be generalised but I could not find any sample files.

With this patch, access to an element via `getindex()` will be materialised if it's a simple entry, like in the example below, which shows an entry at `"Head"` being a `map<string,string>`:

```julia-repl
julia> f = UnROOT.samplefile("triply_jagged_via_custom_class.root");

julia> f["Head"]
Dict{String, String} with 27 entries:
  "muon_desc_file" => " "
  "cut_seamuon"    => " 1000 1e+09 -1 -0.052"
  "physics_1"      => "Corant        4.2.Unve"
  "livetime"       => " 0 0"
  "propag"         => "MUSIC seawater 02-03  190204  1643"
  "seed"           => "corsika       1005340    5004340"
  "cut_nu"         => " 0 0 0 0"
  "detector"       => " "
  "spectrum"       => " 0"
  "physics_2"      => "propa  9310"
  "cut_primary"    => " 1000 1e+09 -1 -0.052"
  "start_run"      => " 4340"
  "coord_origin"   => " 0 0 0 "
  "simul"          => " JSirene 11510 02/06/19 07:07:07"
  "target"         => " "
  "XSecFile"       => " "
  "end_event"      => ""
  "physics"        => " CORSIKA 7.640 181111 1211"
  "seed_1"         => "music           3          1"
  "norma"          => " 1 1000"
  "seabottom"      => " 0"
  "can"            => " 0 977.5 324.6"
  "det_geo"        => ""
  "genhencut"      => " 0 0"
  "DAQ"            => " 3.3"
  "cut_in"         => " 0 1e+09 -1 -0.052"
  "genvol"         => " 0 0 0 0 0"
```