### PR TITLE
weird LRU bug error

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "UnROOT"
 uuid = "3cd96dde-e98d-4713-81e9-a4a1b0235ce9"
 authors = ["Tamas Gal", "Jerry Ling", "Johannes Schumann", "Nick Amin"]
-version = "0.10.2"
+version = "0.10.3"
 
 [deps]
 AbstractTrees = "1520ce14-60c1-5f80-bbc7-55ef81b5835c"
@@ -47,7 +47,6 @@ StaticArrays = "^0.12.0, ^1"
 StructArrays = "0.6"
 Tables = "^1.0.0"
 julia = "^1.6"
-xrootdgo_jll = "^0.32.1"
 
 [extras]
 Arrow = "69666777-d1a9-59fb-9406-91d4454c9d45"

--- a/src/UnROOT.jl
+++ b/src/UnROOT.jl
@@ -57,13 +57,13 @@ include("RNTuple/highlevel.jl")
 include("RNTuple/fieldcolumn_reading.jl")
 include("RNTuple/displays.jl")
 
-let f1 = UnROOT.samplefile("RNTuple/test_ntuple_stl_containers.root")
-    show(devnull, f1["ntuple"])
-    df = LazyTree(f1, "ntuple")
-    collect(df[1])
-    show(devnull, df)
-    show(devnull, df[1])
-end
+# let f1 = UnROOT.samplefile("RNTuple/test_ntuple_stl_containers.root")
+#     show(devnull, f1["ntuple"])
+#     df = LazyTree(f1, "ntuple")
+#     collect(df[1])
+#     show(devnull, df)
+#     show(devnull, df[1])
+# end
 
 if VERSION >= v"1.9"
     let


### PR DESCRIPTION
on 0.10.2 (before), when opening unrelated file, I hit:
```julia
julia> lt = LazyTree("/tmp/0A0C246F-D01B-6F4D-85E6-3A75C27C5197.root", "Events");
ERROR: KeyError: key ((ROOTFile with 1 entry and 1 streamer.
/home/akako/Documents/github/dotFiles/homedir/.julia/dev/UnROOT/test/samples/RNTuple/test_ntuple_stl_containers.root
^C└─ ntuple (ROOT::Experimental::RNTuple)
, "ntuple"), ()) not found
Stacktrace:
  [1] pop!(h::Dict{Any, Tuple{Any, LRUCache.LinkedNode{Any}, Int64}}, key::Tuple{Tuple{ROOTFile, String}, Tuple{}})
    @ Base ./dict.jl:590
  [2] _unsafe_resize!(lru::LRUCache.LRU{Any, Any}, evictions::Vector{Tuple{Any, Any}}, maxsize::Int64)
    @ LRUCache ~/.julia/packages/LRUCache/8li9I/src/LRUCache.jl:179
  [3] _unsafe_resize!
    @ ~/.julia/packages/LRUCache/8li9I/src/LRUCache.jl:176 [inlined]
  [4] get!(default::UnROOT.var"##getter#293#137"{ROOTFile, String}, lru::LRUCache.LRU{Any, Any}, key::Tuple{Tuple{ROOTFile, String}, Tuple{}})
    @ LRUCache ~/.julia/packages/LRUCache/8li9I/src/LRUCache.jl:123
  [5] _get!
    @ ~/.julia/packages/Memoization/xgAKx/src/Memoization.jl:214 [inlined]
  [6] _getindex(f::ROOTFile, s::String)
    @ UnROOT ~/.julia/packages/Memoization/xgAKx/src/Memoization.jl:209
  [7] LazyBranch(f::ROOTFile, s::String)
    @ UnROOT ~/Documents/github/dotFiles/homedir/.julia/dev/UnROOT/src/iteration.jl:125
```

I think our hash function somewhere is not robust enough?