### PR TITLE
Hotfix remove warning

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "UnROOT"
 uuid = "3cd96dde-e98d-4713-81e9-a4a1b0235ce9"
 authors = ["Tamas Gal", "Jerry Ling", "Johannes Schumann", "Nick Amin"]
-version = "0.10.4"
+version = "0.10.5"
 
 [deps]
 AbstractTrees = "1520ce14-60c1-5f80-bbc7-55ef81b5835c"

--- a/src/root.jl
+++ b/src/root.jl
@@ -173,7 +173,7 @@ end
         return S
     end
 
-    @warn "Could not get streamer for $(typename), trying custom streamer."
+    @debug "Could not get streamer for $(typename), trying custom streamer."
     # last resort, try direct parsing
     parsetobject(f.fobj, tkey, streamerfor(f, typename))
 end


### PR DESCRIPTION
The warning pops up for some files where nothing is to be warned about, so let's turn this into `@debug` to avoid confusion (which happened today).