### PR TITLE
Fix type inference issue in basket access

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "UnROOT"
 uuid = "3cd96dde-e98d-4713-81e9-a4a1b0235ce9"
 authors = ["Tamas Gal", "Jerry Ling", "Johannes Schumann", "Nick Amin"]
-version = "0.10.7"
+version = "0.10.8"
 
 [deps]
 AbstractTrees = "1520ce14-60c1-5f80-bbc7-55ef81b5835c"


### PR DESCRIPTION
This PR separates the index calculation of normal baskets and recovered ones in two separate functions. The fix however for https://github.com/JuliaHEP/UnROOT.jl/issues/242 comes from the fact that now the return types are defined to be a `UnitRange{Int}` for both of them.

I did not manage to write a test to check the correct type inference yet.