### PR TITLE
clamp HTTP read to not exceed file size

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -27,9 +27,9 @@ Tables = "bd369af6-aec1-5ad0-b16a-f7cc5008161c"
 xrootdgo_jll = "9d84c17e-11f2-50ef-8cc9-e9701362097f"
 
 [compat]
-Arrow = "2 - 2.5"
 AbstractTrees = "^0.3.0, 0.4"
 ArraysOfArrays = "^0.5.3, ^0.6"
+Arrow = "2 - 2.5"
 BitIntegers = "^0.2.6, ^0.3"
 CodecLz4 = "^0.3.0, ^0.4.0"
 CodecXz = "^0.6.0, ^0.7.0"

--- a/src/streamsource.jl
+++ b/src/streamsource.jl
@@ -120,6 +120,7 @@ end
 
 function read_seek_nb(fobj::HTTPStream, seek, nb)
     stop = seek+nb-1
+    stop = min(fobj.size-1, stop) 
     hd = ("Range" => "bytes=$(seek)-$stop", "Authorization" => "Bearer $(fobj.scitoken)")
     b = HTTP.request(HTTP.stack(), "GET", fobj.uri, hd, UInt8[]).body
     return b

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -431,7 +431,7 @@ end
 end
 
 @testset "NanoAOD" begin
-    rootfile = ROOTFile(joinpath(SAMPLES_DIR, "NanoAODv5_sample.root"))
+    rootfile = UnROOT.samplefile("NanoAODv5_sample.root")
     event = UnROOT.array(rootfile, "Events/event")
     @test event[1:3] == UInt64[12423832, 12423821, 12423834]
     Electron_dxy = LazyBranch(rootfile, "Events/Electron_dxy")
@@ -467,6 +467,8 @@ end
     files = filter(x->endswith(x, ".root"), readdir(SAMPLES_DIR))
     _io = IOBuffer()
     for f in files
+        # https://github.com/JuliaHEP/UnROOT.jl/issues/268
+        contains(f, "km3net_") && continue
         r = ROOTFile(joinpath(SAMPLES_DIR, f))
         show(_io, r)
         close(r)
@@ -993,4 +995,6 @@ end
     @test length(tree.var"PandoraPFOs_covMatrix[10]"[1]) == 790
 end
 
-include("rntuple_tests.jl")
+if VERSION >= v"1.9"
+    include("rntuple_tests.jl")
+end


### PR DESCRIPTION
```julia
julia> ROOTFile("https://xrootd-local.unl.edu:1094//store/user/AGC/nanoAOD/TT_TuneCUETP8M1_13TeV-powheg-pythia8/cmsopendata2015_ttbar_19981_PU25nsData2015v1_76X_mcRun2_asymptotic_v12_ext4-v1_80000_0007.root")
ROOTFile with 7 entries and 30 streamers.
https://xrootd-local.unl.edu:1094//store/user/AGC/nanoAOD/TT_TuneCUETP8M1_13TeV-powheg-pythia8/cmsopendata2015_ttbar_19981_PU25nsData2015v1_76X_mcRun2_asymptotic_v12_ext4-v1_80000_0007.root
├─ Events (TTree)
│  ├─ "run"
│  ├─ "luminosityBlock"
│  ├─ "event"
│  ├─ "⋮"
│  ├─ "HLT_IsoTrackHE"
│  ├─ "HLT_IsoTrackHB"
│  └─ "HLTriggerFinalPath"
├─ LuminosityBlocks (TTree)
│  ├─ "run"
│  └─ "luminosityBlock"
├─ Runs (TTree)
│  ├─ "run"
│  ├─ "genEventCount"
│  ├─ "genEventSumw"
│  ├─ "⋮"
│  ├─ "LHEScaleSumw"
│  ├─ "nLHEPdfSumw"
│  └─ "LHEPdfSumw"
├─ MetaData (TTree)
│  └─ "ProcessHistory"
├─ ParameterSets (TTree)
│  └─ "IdToParameterSetsBlobs"
├─ tag (TObjString)
└─ tag (TObjString)
```
