### PR TITLE
Add a copy(::LazyBranch) method to prevent branch materialization on …

### DIFF
--- a/src/iteration.jl
+++ b/src/iteration.jl
@@ -141,7 +141,7 @@ basketarray_iter(lb::LazyBranch) = basketarray_iter(lb.f, lb.b)
 
     Makes a shallow copy of x.
 """
-Base.copy(x::LazyBranch{T,J,B}) where {T,J,B} = LazyBranch{T,J,B}(x.f, x.b, x.L, x.fEntry, deepcopy(x.buffer),
+Base.copy(x::LazyBranch{T,J,B}) where {T,J,B} = LazyBranch{T,J,B}(x.f, x.b, x.L, x.fEntry, copy.(x.buffer),
                                                                   x.thread_locks, copy(x.buffer_range))
 
 function Base.hash(lb::LazyBranch, h::UInt)

--- a/src/iteration.jl
+++ b/src/iteration.jl
@@ -141,8 +141,8 @@ basketarray_iter(lb::LazyBranch) = basketarray_iter(lb.f, lb.b)
 
     Makes a shallow copy of x.
 """
-Base.copy(x::LazyBranch{T,J,B}) where {T,J,B} = LazyBranch{T,J,B}(x.f, x.b, x.L, x.fEntry, x.buffer,
-                                                                  x.thread_locks, x.buffer_range)
+Base.copy(x::LazyBranch{T,J,B}) where {T,J,B} = LazyBranch{T,J,B}(x.f, x.b, x.L, x.fEntry, deepcopy(x.buffer),
+                                                                  x.thread_locks, copy(x.buffer_range))
 
 function Base.hash(lb::LazyBranch, h::UInt)
     h = hash(lb.f, h)

--- a/src/iteration.jl
+++ b/src/iteration.jl
@@ -130,7 +130,6 @@ function LazyBranch(f::ROOTFile, b::Union{TBranch,TBranchElement})
                                            [_buffer for _ in 1:Nthreads],
                                            [ReentrantLock() for _ in 1:Nthreads],
                                            [0:-1 for _ in 1:Nthreads])
-    end
 end
 
 LazyBranch(f::ROOTFile, s::AbstractString) = LazyBranch(f, f[s])

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -252,6 +252,11 @@ end
     @test [row.int32_array for row in table[20:30]] == BA[20:30]
     @test sum(table.int32_array) == sum(row.int32_array for row in table)
     @test [row.int32_array for row in table] == BA
+    BA_copy = copy(BA)
+    #Check the copy is a LazyBranch:
+    @test typeof(BA_copy) == typeof(BA)
+    #Check the content:
+    @test all(BA .== BA_copy)
     
     # do some hardcoded value checks
     bunches = Float32[]


### PR DESCRIPTION
For a LazyBranch br, Base.copy(br) was returning a vector instead of a LazyBranch and leading to uncessary read. This PR fix the issue.