### PR TITLE
Add error when // is missing from xrootd path

### DIFF
--- a/src/root.jl
+++ b/src/root.jl
@@ -65,6 +65,7 @@ function ROOTFile(filename::AbstractString; customstructs = Dict("TLorentzVector
     fobj = if startswith(filename, r"https?://")
         HTTPStream(filename)
     elseif startswith(filename, "root://")
+        length(findall("//", filename)) == 2 || error("The URL is not misformatted: missing the '//' separator between the server and the path. It should look like 'root://server:1234//path/to/file.root'.")
         sep_idx = findlast("//", filename)
         baseurl = filename[8:first(sep_idx)-1]
         filepath = filename[last(sep_idx):end]

--- a/src/root.jl
+++ b/src/root.jl
@@ -65,7 +65,7 @@ function ROOTFile(filename::AbstractString; customstructs = Dict("TLorentzVector
     fobj = if startswith(filename, r"https?://")
         HTTPStream(filename)
     elseif startswith(filename, "root://")
-        length(findall("//", filename)) == 2 || error("The URL is not misformatted: missing the '//' separator between the server and the path. It should look like 'root://server:1234//path/to/file.root'.")
+        length(findall("//", filename)) == 2 || error("The xrootd URL is illegal: missing the '//' separator between the server and the path (e.g. 'root://server:1234//path/to/file.root')")
         sep_idx = findlast("//", filename)
         baseurl = filename[8:first(sep_idx)-1]
         filepath = filename[last(sep_idx):end]


### PR DESCRIPTION
This simply errors if the xrootd path does not contain the `//` separator and tells the user about it. This is apparently a common typo ;)