### PR TITLE
Fix sumw2 handling when it's empty

### DIFF
--- a/src/streamers.jl
+++ b/src/streamers.jl
@@ -637,5 +637,5 @@ const TArrayI = Vector{Int32}
 
 function readtype(io, T::Type{Vector{U}}) where U <: Union{Integer, AbstractFloat}
     size = readtype(io, Int32)
-    [readtype(io, eltype(T)) for _ in 1:size]
+    U[readtype(io, eltype(T)) for _ in 1:size]
 end

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -121,11 +121,15 @@ function parseTH(th::Dict{Symbol, Any}; raw=true)
         ynbins = th[:fYaxis_fNbins]
         ybins = isempty(th[:fYaxis_fXbins]) ? range(ymin, ymax, length=ynbins+1) : th[:fYaxis_fXbins];
         counts = reshape(counts, (xnbins+2, ynbins+2))[2:end-1, 2:end-1]
-        sumw2 = reshape(sumw2, (xnbins+2, ynbins+2))[2:end-1, 2:end-1]
+        if !isempty(sumw2)
+            sumw2 = reshape(sumw2, (xnbins+2, ynbins+2))[2:end-1, 2:end-1]
+        end
         edges = (xbins, ybins)
     else
         counts = counts[2:end-1]
-        sumw2 = sumw2[2:end-1]
+        if !isempty(sumw2)
+            sumw2 = sumw2[2:end-1]
+        end
         edges = (xbins,)
     end
     if raw


### PR DESCRIPTION
Fixes an issue when parsing histograms with empty `sumw2` arrays.

Tests are still missing.