### PR TITLE
Add support for more primitive (vector/jagged) leaf types

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "UnROOT"
 uuid = "3cd96dde-e98d-4713-81e9-a4a1b0235ce9"
 authors = ["Tamas Gal", "Jerry Ling", "Johannes Schumann", "Nick Amin"]
-version = "0.10.20"
+version = "0.10.21"
 
 [deps]
 AbstractTrees = "1520ce14-60c1-5f80-bbc7-55ef81b5835c"

--- a/src/root.jl
+++ b/src/root.jl
@@ -391,14 +391,28 @@ function auto_T_JaggT(f::ROOTFile, branch; customstructs::Dict{String, Type})
             # TODO unify this with the "switch" block below and expand for more types!
             if _jaggtype == Offsetjagg
                 streamer.fTypeName == "vector<string>" && return Vector{String}, _jaggtype
+                streamer.fTypeName == "vector<float>" && return Vector{Float32}, _jaggtype
                 streamer.fTypeName == "vector<double>" && return Vector{Float64}, _jaggtype
+                streamer.fTypeName == "vector<short>" && return Vector{Int16}, _jaggtype
                 streamer.fTypeName == "vector<int>" && return Vector{Int32}, _jaggtype
+                streamer.fTypeName == "vector<long>" && return Vector{Int64}, _jaggtype
+                streamer.fTypeName == "vector<unsigned short>" && return Vector{UInt16}, _jaggtype
                 streamer.fTypeName == "vector<unsigned int>" && return Vector{UInt32}, _jaggtype
+                streamer.fTypeName == "vector<unsigned long>" && return Vector{UInt64}, _jaggtype
+                streamer.fTypeName == "vector<signed char>" && return Vector{Int8}, _jaggtype
+                streamer.fTypeName == "vector<unsigned char>" && return Vector{UInt8}, _jaggtype
             elseif _jaggtype == Offsetjaggjagg || _jaggtype == Offset6jaggjagg
                 streamer.fTypeName == "vector<string>" && return Vector{Vector{String}}, _jaggtype
+                streamer.fTypeName == "vector<float>" && return Vector{Vector{Float32}}, _jaggtype
                 streamer.fTypeName == "vector<double>" && return Vector{Vector{Float64}}, _jaggtype
+                streamer.fTypeName == "vector<short>" && return Vector{Vector{Int16}}, _jaggtype
                 streamer.fTypeName == "vector<int>" && return Vector{Vector{Int32}}, _jaggtype
+                streamer.fTypeName == "vector<long>" && return Vector{Vector{Int64}}, _jaggtype
+                streamer.fTypeName == "vector<unsigned short>" && return Vector{Vector{UInt16}}, _jaggtype
                 streamer.fTypeName == "vector<unsigned int>" && return Vector{Vector{UInt32}}, _jaggtype
+                streamer.fTypeName == "vector<unsigned long>" && return Vector{Vector{UInt64}}, _jaggtype
+                streamer.fTypeName == "vector<signed char>" && return Vector{Vector{Int8}}, _jaggtype
+                streamer.fTypeName == "vector<unsigned char>" && return Vector{Vector{UInt8}}, _jaggtype
             end
 
         end

--- a/src/root.jl
+++ b/src/root.jl
@@ -393,10 +393,12 @@ function auto_T_JaggT(f::ROOTFile, branch; customstructs::Dict{String, Type})
                 streamer.fTypeName == "vector<string>" && return Vector{String}, _jaggtype
                 streamer.fTypeName == "vector<double>" && return Vector{Float64}, _jaggtype
                 streamer.fTypeName == "vector<int>" && return Vector{Int32}, _jaggtype
+                streamer.fTypeName == "vector<unsigned int>" && return Vector{UInt32}, _jaggtype
             elseif _jaggtype == Offsetjaggjagg || _jaggtype == Offset6jaggjagg
                 streamer.fTypeName == "vector<string>" && return Vector{Vector{String}}, _jaggtype
                 streamer.fTypeName == "vector<double>" && return Vector{Vector{Float64}}, _jaggtype
                 streamer.fTypeName == "vector<int>" && return Vector{Vector{Int32}}, _jaggtype
+                streamer.fTypeName == "vector<unsigned int>" && return Vector{Vector{UInt32}}, _jaggtype
             end
 
         end


### PR DESCRIPTION
Just a small PR which adds several vector/jagged primitive support for leaf types. This is a quick fix for https://github.com/JuliaHEP/UnROOT.jl/issues/298