### PR TITLE
Extended support for TNamed (when living freely) and TFriendTree

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "UnROOT"
 uuid = "3cd96dde-e98d-4713-81e9-a4a1b0235ce9"
 authors = ["Tamas Gal", "Jerry Ling", "Johannes Schumann", "Nick Amin"]
-version = "0.10.21"
+version = "0.10.22"
 
 [deps]
 AbstractTrees = "1520ce14-60c1-5f80-bbc7-55ef81b5835c"

--- a/src/bootstrap.jl
+++ b/src/bootstrap.jl
@@ -58,7 +58,7 @@ abstract type TNamed <: ROOTStreamedObject end
 # TODO: we probably should switch over to @kwdef at some point, but that's another big refactoring
 # Cursor is not needed here but it's mandatory due to the historical design of UnROOT and the
 # parsefields approach
-@kwdef struct TNamed_1 <: TNamed
+Base.@kwdef struct TNamed_1 <: TNamed
     cursor::Cursor
     fName::String
     fTitle::String
@@ -1195,7 +1195,7 @@ end
 # https://github.com/scikit-hep/uproot3/blob/54f5151fb7c686c3a161fbe44b9f299e482f346b/uproot3/interp/auto.py#L360-L365
 
 abstract type TFriendElement <: ROOTStreamedObject end
-@kwdef struct TFriendElement_2 <: TFriendElement
+Base.@kwdef struct TFriendElement_2 <: TFriendElement
     cursor::Cursor
     fName::String
     fTitle::String

--- a/src/bootstrap.jl
+++ b/src/bootstrap.jl
@@ -55,11 +55,29 @@ function unpack(io, tkey::TKey, refs::Dict{Int32, Any}, T::Type{RecoveredTBasket
 end
 
 abstract type TNamed <: ROOTStreamedObject end
-struct TNamed_1 <: TNamed end
+# TODO: we probably should switch over to @kwdef at some point, but that's another big refactoring
+# Cursor is not needed here but it's mandatory due to the historical design of UnROOT and the
+# parsefields approach
+@kwdef struct TNamed_1 <: TNamed
+    cursor::Cursor
+    fName::String
+    fTitle::String
+end
 function readfields!(io, fields, ::Type{TNamed_1})
     parsefields!(io, fields, TObject)
     fields[:fName] = readtype(io, String)
     fields[:fTitle] = readtype(io, String)
+end
+# TODO: this is an ugly hack due to some ambiguities of readfields!-definitions.
+# A big cleanup is needed!
+# We need to define something like the following (that's not working, too tired already...)
+# parsefields!(c::Cursor, fields, TObject) = parsefields!(c.io, fields, TObject)
+# readtype(c::Cursor, ::Type{T}) where T = readtype(c.io, T)
+function readfields!(c::Cursor, fields, ::Type{TNamed_1})
+    parsefields!(c.io, fields, TObject)
+    fields[:fName] = readtype(c.io, String)
+    fields[:fTitle] = readtype(c.io, String)
+    @show fields
 end
 
 abstract type TAttLine <: ROOTStreamedObject end
@@ -1176,3 +1194,24 @@ end
 
 # FIXME what to do with auto.py's massive type translation?
 # https://github.com/scikit-hep/uproot3/blob/54f5151fb7c686c3a161fbe44b9f299e482f346b/uproot3/interp/auto.py#L360-L365
+
+abstract type TFriendElement <: ROOTStreamedObject end
+@kwdef struct TFriendElement_2 <: TFriendElement
+    cursor::Cursor
+    fName::String
+    fTitle::String
+    fTreeName::String
+    fOwnFile::Bool
+end
+function readfields!(io, fields, ::Type{TFriendElement_2})
+    stream!(io, fields, TNamed)
+    fields[:fTreeName] = readtype(io, String)
+    fields[:fOwnFile] = readtype(io, Bool)
+end
+# TODO: this is an ugly hack due to some ambiguities of readfields!-definitions.
+# A big cleanup is needed!
+function readfields!(c::Cursor, fields, ::Type{TFriendElement_2})
+    stream!(c.io, fields, TNamed)
+    fields[:fTreeName] = readtype(c.io, String)
+    fields[:fOwnFile] = readtype(c.io, Bool)
+end

--- a/src/bootstrap.jl
+++ b/src/bootstrap.jl
@@ -77,7 +77,6 @@ function readfields!(c::Cursor, fields, ::Type{TNamed_1})
     parsefields!(c.io, fields, TObject)
     fields[:fName] = readtype(c.io, String)
     fields[:fTitle] = readtype(c.io, String)
-    @show fields
 end
 
 abstract type TAttLine <: ROOTStreamedObject end


### PR DESCRIPTION
Yet another PR which makes me uncomfortable since it again shows that we need to refactor the backend, but for now I am happy that UnROOT is finally able to read our (KM3NeT) summary files, which is one of the last missing pieces in the data accessibility chain.

### before:

```julia
julia> using UnROOT, KM3NeTTestData

julia> f = ROOTFile(datapath("dst", "orca4_sample.root"))
ROOTFile with 5 entries and 31 streamers.
/Users/tamasgal/.julia/packages/KM3NeTTestData/fq1dM/src/../km3net_testdata/data/dst/orca4_sample.root
├─ T (TTree)
│  ├─ "sum_trks"
│  ├─ "sum_hits"
│  ├─ "sum_trig_hits"
│  ├─ "coords"
│  ├─ "cherenkovCond"
│  └─ "ORCAanalysis"
├─ Head (Head)
├─ dst_history (TDirectory)
│  ├─ input_files (TNamed)
│  └─ command_line (TNamed)
└─ HeadDir (TDirectory)
   ├─ DAQ (TNamed)
   └─ start_run (TNamed)


julia> f["E"]
ERROR: MethodError: no method matching read(::UnROOT.Cursor, ::Type{Int16})

Closest candidates are:
  read(::UnROOT.OffsetBuffer, ::Any)
   @ UnROOT ~/Dev/UnROOT.jl/src/UnROOT.jl:33
  read(::Base.GenericIOBuffer, ::Union{Type{Float16}, Type{Float32}, Type{Float64}, Type{Int128}, Type{Int16}, Type{Int32}, Type{Int64}, Type{UInt128}, Type{UInt16}, Type{UInt32}, Type{UInt64}})
   @ Base iobuffer.jl:189
  read(::AbstractString, ::Type{T}) where T
   @ Base io.jl:473
  ...
```

### after (now we can access the `E` tree):

```julia
julia> using UnROOT, KM3NeTTestData

julia> f = ROOTFile(datapath("dst", "orca4_sample.root"))
ROOTFile with 5 entries and 31 streamers.
/Users/tamasgal/.julia/packages/KM3NeTTestData/fq1dM/src/../km3net_testdata/data/dst/orca4_sample.root
├─ E (TTree)
│  └─ "Evt"
├─ T (TTree)
│  ├─ "sum_trks"
│  ├─ "sum_hits"
│  ├─ "sum_trig_hits"
│  ├─ "coords"
│  ├─ "cherenkovCond"
│  └─ "ORCAanalysis"
├─ Head (Head)
├─ dst_history (TDirectory)
│  ├─ input_files (TNamed)
│  └─ command_line (TNamed)
└─ HeadDir (TDirectory)
   ├─ DAQ (TNamed)
   └─ start_run (TNamed)


julia> f["E"]
E (TTree)
└─ "Evt"


julia> f["E/Evt"]
Evt
├─ AAObject
│  ├─ TObject
│  │  ├─ fUniqueID
│  │  └─ fBits
│  ├─ usr
│  ├─ usr_names
│  └─ any
├─ id
├─ det_id
├─ mc_id
├─ run_id
├─ mc_run_id
├─ frame_index
├─ trigger_mask
├─ trigger_counter
├─ overlays
├─ t
│  ├─ t.fSec
│  └─ t.fNanoSec
├─ hits
│  ├─ hits.fUniqueID
│  ├─ hits.fBits
│  ├─ hits.id
│  ├─ hits.dom_id
│  ├─ hits.channel_id
│  ├─ hits.tdc
│  ├─ hits.tot
│  ├─ hits.trig
│  ├─ hits.pmt_id
│  ├─ hits.t
│  ├─ hits.a
│  ├─ hits.pos.x
│  ├─ hits.pos.y
│  ├─ hits.pos.z
│  ├─ hits.dir.x
│  ├─ hits.dir.y
│  ├─ hits.dir.z
│  ├─ hits.type
│  ├─ hits.origin
│  └─ hits.pattern_flags
├─ trks
│  ├─ trks.fUniqueID
│  ├─ trks.fBits
│  ├─ trks.usr
│  ├─ trks.usr_names
│  ├─ trks.any
│  ├─ trks.id
│  ├─ trks.pos.x
│  ├─ trks.pos.y
│  ├─ trks.pos.z
│  ├─ trks.dir.x
│  ├─ trks.dir.y
│  ├─ trks.dir.z
│  ├─ trks.t
│  ├─ trks.E
│  ├─ trks.len
│  ├─ trks.lik
│  ├─ trks.type
│  ├─ trks.rec_type
│  ├─ trks.rec_stages
│  ├─ trks.status
│  ├─ trks.mother_id
│  ├─ trks.fitinf
│  ├─ trks.hit_ids
│  ├─ trks.error_matrix
│  └─ trks.comment
├─ w
├─ w2list
├─ w3list
├─ mc_event_time
│  ├─ mc_event_time.fSec
│  └─ mc_event_time.fNanoSec
├─ mc_t
├─ mc_hits
│  ├─ mc_hits.fUniqueID
│  ├─ mc_hits.fBits
│  ├─ mc_hits.id
│  ├─ mc_hits.dom_id
│  ├─ mc_hits.channel_id
│  ├─ mc_hits.tdc
│  ├─ mc_hits.tot
│  ├─ mc_hits.trig
│  ├─ mc_hits.pmt_id
│  ├─ mc_hits.t
│  ├─ mc_hits.a
│  ├─ mc_hits.pos.x
│  ├─ mc_hits.pos.y
│  ├─ mc_hits.pos.z
│  ├─ mc_hits.dir.x
│  ├─ mc_hits.dir.y
│  ├─ mc_hits.dir.z
│  ├─ mc_hits.type
│  ├─ mc_hits.origin
│  └─ mc_hits.pattern_flags
├─ mc_trks
│  ├─ mc_trks.fUniqueID
│  ├─ mc_trks.fBits
│  ├─ mc_trks.usr
│  ├─ mc_trks.usr_names
│  ├─ mc_trks.any
│  ├─ mc_trks.id
│  ├─ mc_trks.pos.x
│  ├─ mc_trks.pos.y
│  ├─ mc_trks.pos.z
│  ├─ mc_trks.dir.x
│  ├─ mc_trks.dir.y
│  ├─ mc_trks.dir.z
│  ├─ mc_trks.t
│  ├─ mc_trks.E
│  ├─ mc_trks.len
│  ├─ mc_trks.lik
│  ├─ mc_trks.type
│  ├─ mc_trks.rec_type
│  ├─ mc_trks.rec_stages
│  ├─ mc_trks.status
│  ├─ mc_trks.mother_id
│  ├─ mc_trks.fitinf
│  ├─ mc_trks.hit_ids
│  ├─ mc_trks.error_matrix
│  └─ mc_trks.comment
├─ comment
├─ index
└─ flags
```