### PR TITLE
Remove nightly Julia build from CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,11 +23,6 @@ jobs:
         os: [ubuntu-latest]
         arch: [x64]
         allow_failure: [false]
-        include:
-          - version: 'nightly'
-            os: ubuntu-latest
-            arch: x64
-            allow_failure: true
     steps:
       - uses: actions/checkout@v2
       - uses: julia-actions/setup-julia@v1


### PR DESCRIPTION
The nightly build is often broken and the CI badge shows "failing" because it picks that up.
I don't think we need to waste resources on the nightly Julia CI anyways.