### PR TITLE
Allow hooking into parsetobject

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "UnROOT"
 uuid = "3cd96dde-e98d-4713-81e9-a4a1b0235ce9"
 authors = ["Tamas Gal", "Jerry Ling", "Johannes Schumann", "Nick Amin"]
-version = "0.10.22"
+version = "0.10.23"
 
 [deps]
 AbstractTrees = "1520ce14-60c1-5f80-bbc7-55ef81b5835c"

--- a/src/root.jl
+++ b/src/root.jl
@@ -185,7 +185,7 @@ function _getindex(f::ROOTFile, s)
 
     @debug "Could not get streamer for $(typename), trying custom streamer."
     # last resort, try direct parsing
-    parsetobject(f.fobj, tkey, streamerfor(f, typename))
+    parsetobject(f, tkey, streamerfor(f, typename))
 end
 
 function getindex(d::ROOTDirectory, s)


### PR DESCRIPTION
Currently, when calling `_getindex(f::ROOTFile, s)` a streamer is picked up and when the corresponding type is defined, the streamer is then called with the file object, tkey and refs. The point is that objects can also sit at top-level. In `_getindex` the type has to be defined in the namespace of `UnROOT`. That's still something I am not fully happy with but it works so far.

If there is no type defined (called `tkey.fClassName`, in the namespace of `UnROOT`), the function `parsetobject` is called which essentially tries to instantiate the full data as a last resort. This approach completely goes another path and the `Lazy*` mechanics are also bypassed.

As of now, passing `customstructs=Dict{String, Type}(...)` to the `ROOTFile` allows to hook into the streamer logic at the late `auto_T_JaggT` stage which is only reached for objects in a `ROOTDirectory`, via `getindex(d::ROOTDirectory, s)`.

This PR adds the ability to use a custom streamer directly inside the `parsetobject` function, using the same `customstructs` dictionary.

We really(!) need to refactor these stuff at some point; we can unify a couple of things already, but this is a lot of work.