### PR TITLE
Hotfix for flat vector of vectors

### DIFF
--- a/src/iteration.jl
+++ b/src/iteration.jl
@@ -120,7 +120,7 @@ mutable struct LazyBranch{T,J,B} <: AbstractVector{T}
         if J != Nojagg
             # if branch is jagged, fix the buffer and eltype according to what
             # VectorOfVectors would return in `getindex`
-            _buffer = VectorOfVectors(T(), Int32[1])
+            _buffer = isbitstype(T) ? VectorOfVectors(T[], Int32[1]) : VectorOfVectors(T(), Int32[1])
             T = SubArray{eltype(T), 1, T, Tuple{UnitRange{Int64}}, true}
         end
         Nthreads = _maxthreadid()

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -728,6 +728,13 @@ end
     # issue 246
     arr = LazyTree(joinpath(SAMPLES_DIR, "issue246.root"), "tree_NOMINAL").v_mcGenWgt
     @test all(reduce(vcat, arr) .== 1.0)
+
+    # issue 323
+    f = ROOTFile(joinpath(SAMPLES_DIR, "issue323.root"))
+    LazyTree(f, "sim", [r"ghost/ghost\.(.*)" => s"\1"])
+    @test 1200 == length(t)
+    @test t[1].time[2] ≈ 36.396744f0
+    @test t[end].xpos[end] ≈ 788.35144f0
 end
 
 @testset "jagged subbranch type by leaf" begin

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -731,7 +731,7 @@ end
 
     # issue 323
     f = ROOTFile(joinpath(SAMPLES_DIR, "issue323.root"))
-    LazyTree(f, "sim", [r"ghost/ghost\.(.*)" => s"\1"])
+    t = LazyTree(f, "sim", [r"ghost/ghost\.(.*)" => s"\1"])
     @test 1200 == length(t)
     @test t[1].time[2] ≈ 36.396744f0
     @test t[end].xpos[end] ≈ 788.35144f0


### PR DESCRIPTION
Fixes the case where the type is bitstype. Closes #323