### PR TITLE
allow more than two // for xrootd path and remove `asyncmap`

### DIFF
--- a/src/iteration.jl
+++ b/src/iteration.jl
@@ -271,12 +271,11 @@ Base.getindex(lt::LazyTree, row::Int) = LazyEvent(Tables.columns(lt), row)
 Base.getindex(lt::LazyTree, row::CartesianIndex{1}) = LazyEvent(Tables.columns(lt), row[1])
 function Base.getindex(lt::LazyTree, rang)
     bnames = propertynames(lt)
-    branches = asyncmap(b->getproperty(lt, b)[rang], bnames)
+    branches = map(b->getproperty(lt, b)[rang], bnames)
     return LazyTree(NamedTuple{bnames}(branches))
 end
 
 function Base.view(lt::LazyTree, idx...)
-    bnames = propertynames(lt)
     return LazyTree(map(x->view(x, idx...), Tables.columns(lt)))
 end
 
@@ -484,7 +483,7 @@ function Base.getindex(ba::LazyBranch{T,J,B}, range::UnitRange) where {T,J,B}
         iths = ib1-1:ib2-1
     end
     range = (first(range)-offset):(last(range)-offset)
-    return ChainedVector(asyncmap(i->basketarray(ba, i), iths))[range]
+    return ChainedVector(map(i->basketarray(ba, i), iths))[range]
 end
 
 _clusterranges(t::LazyTree) = _clusterranges([getproperty(t,p) for p in propertynames(t)])

--- a/src/root.jl
+++ b/src/root.jl
@@ -66,8 +66,8 @@ function ROOTFile(filename::AbstractString; customstructs = Dict("TLorentzVector
     fobj = if startswith(filename, r"https?://")
         HTTPStream(filename)
     elseif startswith(filename, "root://")
-        length(findall("//", filename)) == 2 || error("The xrootd URL is illegal: missing the '//' separator between the server and the path (e.g. 'root://server:1234//path/to/file.root')")
-        sep_idx = findlast("//", filename)
+        length(findall("//", filename)) < 2 && error("The xrootd URL is illegal: missing the '//' separator between the server and the path (e.g. 'root://server:1234//path/to/file.root')")
+        sep_idx = findall("//", filename)[2]
         baseurl = filename[8:first(sep_idx)-1]
         filepath = filename[last(sep_idx):end]
         XRDStream(baseurl, filepath, "go")


### PR DESCRIPTION
Fixes #334

for some large, bulk allocation:
```julia
const rf = ROOTFile("root://192.170.240.144//root://fax.mwt2.org:1094//pnfs/uchicago.edu/atlaslocalgroupdisk/rucio/data18_13TeV/ab/ae/DAOD_PHYSLITE.37021783._000016.pool.root.1")

@time LazyTree(rf, "CollectionTree", BRANCH_LIST)[1:1000]
@time LazyTree(rf, "CollectionTree", BRANCH_LIST)[:]
```

## Before
```
$ julia --project=./.julia/dev/UnROOT 200gbps.jl
  9.149127 seconds (6.53 M allocations: 651.924 MiB, 5.94% gc time, 57.00% compilation time)
233.410383 seconds (29.62 M allocations: 9.726 GiB, 0.99% gc time, 0.00% compilation time)
```

## After
```
$ julia --project=./.julia/dev/UnROOT 200gbps.jl
  5.265043 seconds (6.31 M allocations: 636.040 MiB, 8.73% gc time, 86.63% compilation time)
 13.720679 seconds (29.40 M allocations: 9.716 GiB, 14.92% gc time, 0.05% compilation time)
```