### PR TITLE
[RNTuple] Writing: support String and Bool types, and Vector Field

### DIFF
--- a/.github/workflows/cvmfs.yml
+++ b/.github/workflows/cvmfs.yml
@@ -28,9 +28,15 @@ jobs:
       - uses: julia-actions/julia-buildpkg@v1
       - name: Generate root file
         run: |
-          julia --project ./test/RNTupleWriting/output_sample.jl test1.root
+          julia --code-coverage --project ./test/RNTupleWriting/output_sample.jl test1.root
       - uses: cvmfs-contrib/github-action-cvmfs@v4
       - name: Read root file in C++
         run: |
           source /cvmfs/sft.cern.ch/lcg/views/dev3/latest/x86_64-ubuntu2204-gcc11-opt/setup.sh
           python ./test/RNTupleWriting/test1.py test1.root
+      - uses: julia-actions/julia-processcoverage@v1
+      - uses: codecov/codecov-action@v4
+        env:
+          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
+        with:
+          file: lcov.info

--- a/src/RNTuple/Writing/TFileWriter.jl
+++ b/src/RNTuple/Writing/TFileWriter.jl
@@ -518,7 +518,7 @@ function schema_to_field_column_records(table)
     column_records = UnROOT.ColumnRecord[]
 
     for (input_T, input_name) in zip(input_Ts, input_names)
-        add_field_column_record!(field_records, column_records, input_T, input_name, parent_field_id=length(field_records), col_field_id=length(column_records))
+        add_field_column_record!(field_records, column_records, input_T, input_name, parent_field_id=length(field_records))
     end
     return field_records, column_records
 end
@@ -546,9 +546,6 @@ function write_rntuple(file::IO, table; file_name="test_ntuple_minimal.root", rn
         error("Top-level columns must have the same length")
     end
     input_length = length(input_cols[begin])
-    if input_length > 65535
-        error("Input too long: RNTuple writing currently only supports a single page (65535 elements)")
-    end
 
     rntAnchor_update = Dict{Symbol, Any}()
 

--- a/src/RNTuple/Writing/TFileWriter.jl
+++ b/src/RNTuple/Writing/TFileWriter.jl
@@ -482,6 +482,19 @@ function add_field_column_record!(field_records, column_records, input_T::Type{<
     nothing
 end
 
+# string case
+function add_field_column_record!(field_records, column_records, input_T::Type{<:AbstractString}, NAME; parent_field_id, col_field_id = parent_field_id)
+    implicit_field_id = length(field_records)
+    fr =  UnROOT.FieldRecord(; field_version=0x00000000, type_version=0x00000000, parent_field_id, struct_role=0x0000, flags=0x0000, repetition=0, source_field_id=-1, root_streamer_checksum=-1, field_name=string(NAME), type_name="std::string", type_alias="", field_desc="", )
+    push!(field_records, fr)
+
+    cr_offset = UnROOT.ColumnRecord(RNTUPLE_WRITE_TYPE_IDX_DICT[Index64]..., col_field_id, 0x00, 0x00, 0)
+    push!(column_records, cr_offset)
+    cr_chars = UnROOT.ColumnRecord(RNTUPLE_WRITE_TYPE_IDX_DICT[Char]..., col_field_id, 0x00, 0x00, 0)
+    push!(column_records, cr_chars)
+    nothing
+end
+
 # vector case
 function add_field_column_record!(field_records, column_records, input_T::Type{<:AbstractVector}, NAME; parent_field_id, col_field_id = parent_field_id)
     implicit_field_id = length(field_records)

--- a/src/RNTuple/Writing/TFileWriter.jl
+++ b/src/RNTuple/Writing/TFileWriter.jl
@@ -525,6 +525,9 @@ function write_rntuple(file::IO, table; file_name="test_ntuple_minimal.root", rn
     end
 
     input_cols = columntable(table)
+    if !allequal(length, input_cols)
+        error("Top-level columns must have the same length")
+    end
     input_length = length(input_cols[begin])
     if input_length > 65535
         error("Input too long: RNTuple writing currently only supports a single page (65535 elements)")

--- a/src/RNTuple/Writing/constants.jl
+++ b/src/RNTuple/Writing/constants.jl
@@ -1,4 +1,6 @@
 const RNTUPLE_WRITE_TYPE_IDX_DICT = Dict(
+    Index64 => (0x01, sizeof(Index64) * 8),
+    Index32 => (0x02, sizeof(Index32) * 8),
     Float64 => (0x10, sizeof(UInt64) * 8),
     Float32 => (0x11, sizeof(UInt32) * 8),
     Float16 => (0x12, sizeof(UInt16) * 8),

--- a/src/RNTuple/Writing/constants.jl
+++ b/src/RNTuple/Writing/constants.jl
@@ -1,6 +1,7 @@
 const RNTUPLE_WRITE_TYPE_IDX_DICT = Dict(
     Index64 => (0x01, sizeof(Index64) * 8),
     Index32 => (0x02, sizeof(Index32) * 8),
+    Char => (0x05, 8),
     Bool => (0x06, 1),
     Float64 => (0x10, sizeof(UInt64) * 8),
     Float32 => (0x11, sizeof(UInt32) * 8),

--- a/src/RNTuple/Writing/constants.jl
+++ b/src/RNTuple/Writing/constants.jl
@@ -1,6 +1,7 @@
 const RNTUPLE_WRITE_TYPE_IDX_DICT = Dict(
     Index64 => (0x01, sizeof(Index64) * 8),
     Index32 => (0x02, sizeof(Index32) * 8),
+    Bool => (0x06, 1),
     Float64 => (0x10, sizeof(UInt64) * 8),
     Float32 => (0x11, sizeof(UInt32) * 8),
     Float16 => (0x12, sizeof(UInt16) * 8),
@@ -14,6 +15,7 @@ const RNTUPLE_WRITE_TYPE_IDX_DICT = Dict(
 )
 
 const RNTUPLE_WRITE_TYPE_CPPNAME_DICT = Dict(
+    Bool => "bool",
     Float16 => "std::float16_t",
     Float32 => "float",
     Float64 => "double",

--- a/src/RNTuple/Writing/page_writing.jl
+++ b/src/RNTuple/Writing/page_writing.jl
@@ -1,4 +1,22 @@
 """
+    rnt_col_to_ary(col) -> Vector{Vector}
+
+Normalize each user-facing "column" into a collection of Vector{<:Real} ready to be written to a page.
+After calling this on all user-facing "column", we should have as many `ary`s as our `ColumnRecord`s.
+"""
+rnt_col_to_ary(col::AbstractVector{<:Real}) = Any[col]
+
+function rnt_col_to_ary(col::AbstractVector{<:AbstractVector})
+    vov = VectorOfVectors(col)
+    content = flatview(vov)
+    # 0-based indexing
+    offset = ArraysOfArrays.element_ptr(vov) .- 1
+    offset_adjust = @view offset[begin+1:end]
+
+    Any[rnt_col_to_ary(offset_adjust); rnt_col_to_ary(content)]
+end
+
+"""
     rnt_ary_to_page(ary::AbstractVector, cr::ColumnRecord) end
 
 Turns an AbstractVector into a page of an RNTuple. The element type must be primitive for this to work.

--- a/src/RNTuple/Writing/page_writing.jl
+++ b/src/RNTuple/Writing/page_writing.jl
@@ -24,6 +24,11 @@ Turns an AbstractVector into a page of an RNTuple. The element type must be prim
 """
 function rnt_ary_to_page(ary::AbstractVector, cr::ColumnRecord) end
 
+function rnt_ary_to_page(ary::AbstractVector{Bool}, cr::ColumnRecord)
+    chunks = BitVector(ary).chunks
+    Page_write(reinterpret(UInt8, chunks))
+end
+
 function rnt_ary_to_page(ary::AbstractVector{Float64}, cr::ColumnRecord)
     (;split, zigzag, delta) = _detect_encoding(cr.type)
     if split

--- a/src/RNTuple/Writing/page_writing.jl
+++ b/src/RNTuple/Writing/page_writing.jl
@@ -16,6 +16,10 @@ function rnt_col_to_ary(col::AbstractVector{<:AbstractVector})
     Any[rnt_col_to_ary(offset_adjust); rnt_col_to_ary(content)]
 end
 
+function rnt_col_to_ary(col::AbstractVector{<:AbstractString})
+    rnt_col_to_ary(codeunits.(col))
+end
+
 """
     rnt_ary_to_page(ary::AbstractVector, cr::ColumnRecord) end
 
@@ -23,6 +27,7 @@ Turns an AbstractVector into a page of an RNTuple. The element type must be prim
 
 """
 function rnt_ary_to_page(ary::AbstractVector, cr::ColumnRecord) end
+
 
 function rnt_ary_to_page(ary::AbstractVector{Bool}, cr::ColumnRecord)
     chunks = BitVector(ary).chunks
@@ -81,6 +86,10 @@ function rnt_ary_to_page(ary::AbstractVector{UInt16}, cr::ColumnRecord)
     else
         Page_write(reinterpret(UInt8, ary))
     end
+end
+
+function rnt_ary_to_page(ary::AbstractVector{UInt8}, cr::ColumnRecord)
+    Page_write(ary)
 end
 
 function rnt_ary_to_page(ary::AbstractVector{Int64}, cr::ColumnRecord)

--- a/src/RNTuple/fieldcolumn_reading.jl
+++ b/src/RNTuple/fieldcolumn_reading.jl
@@ -105,7 +105,8 @@ function read_field(io, field::LeafField{Bool}, page_list)
 
     # pad to nearest 8*k bytes because each chunk needs to be UInt64
     bytes = read_pagedesc(io, pages, cr)
-    append!(bytes, zeros(eltype(bytes), (64 - rem(total_num_elements, 64))÷8))
+    N_pad = 8 - mod1(length(bytes), 8)
+    append!(bytes, zeros(eltype(bytes), N_pad))
     chunks = reinterpret(UInt64, bytes)
 
     res = BitVector(undef, total_num_elements)

--- a/test/RNTupleWriting/lowlevel.jl
+++ b/test/RNTupleWriting/lowlevel.jl
@@ -236,8 +236,10 @@ end
     @test field_ids == [0,1,2,3,4,5]
 end
 
+const RNT_primitive_Ts = [Bool, Float64, Float32, Float16, Int64, Int32, Int16, Int8, UInt64, UInt32, UInt16]
+
 @testset "RNTuple Writing - Single colunm round trips" begin
-for _ = 1:10, T in [Float64, Float32, Float16, Int64, Int32, Int16, Int8, UInt64, UInt32, UInt16]
+for _ = 1:10, T in RNT_primitive_Ts
     newtable = Dict(randstring(rand(2:10)) => rand(T, rand(1:100)))
     newio = IOBuffer()
     UnROOT.write_rntuple(newio, newtable)
@@ -260,7 +262,7 @@ end
 end
 
 @testset "RNTuple Writing - Multiple colunm round trips" begin
-    Ts = rand([Float64, Float32, Float16, Int64, Int32, Int16, Int8, UInt64, UInt32, UInt16], 15)
+    Ts = rand(RNT_primitive_Ts, 15)
     Nitems = rand(10:1000)
     newtable = Dict(randstring(rand(2:10)) => rand(T, Nitems) for T in Ts)
     newio = IOBuffer()
@@ -284,7 +286,7 @@ end
 end
 
 @testset "RNTuple Writing - Vector colunms" begin
-    Ts = rand([Float64, Float32, Float16, Int64, Int32, Int16, Int8, UInt64, UInt32, UInt16], 15)
+    Ts = rand(RNT_primitive_Ts, 15)
     inner_Nitems = [3,4,0,0,1,2]
     newtable = Dict(randstring(rand(2:10)) => [rand(T, Nitems) for Nitems in inner_Nitems] for T in Ts)
     newio = IOBuffer()

--- a/test/RNTupleWriting/output_sample.jl
+++ b/test/RNTupleWriting/output_sample.jl
@@ -1,11 +1,15 @@
 using UnROOT
 
+const RNT_primitive_Ts = [Float64, Float32, Float16, Int64, Int32, Int16, Int8, UInt64, UInt32, UInt16]
 Nitems = 10
 data = [5, 6, 7, 8, 9, 10, 11, 12, 13, 14]
-newtable = Dict(
-    "x1" => Float64.(data),
-    "x2" => Float32.(data),
-    "x3" => Int32.(data),
-    "y1" => UInt16.(data),
-)
+
+newtable = Dict( "x_$T" => T.(data) for T in RNT_primitive_Ts)
+newtable["x_Bool"] = isodd.(data)
+newtable["x_String"] = string.(data)
+
+for T in RNT_primitive_Ts
+    newtable["x_vec_$T"] = [rand(T, data[i]) for i in 1:Nitems]
+end
+
 UnROOT.write_rntuple(open(only(ARGS), "w"), newtable; rntuple_name="myntuple")

--- a/test/RNTupleWriting/test1.py
+++ b/test/RNTupleWriting/test1.py
@@ -1,9 +1,15 @@
 import ROOT
 import sys
 
+Nitems = 10
+data = [5, 6, 7, 8, 9, 10, 11, 12, 13, 14]
+
 df  =  ROOT.RDataFrame("myntuple", sys.argv[1])
-if len(list(df.GetColumnNames())) != 4:
+
+if list(df.Take['std::int32_t']("x_Int32")) != data:
+    sys.exit(1)
+if list(df.Take['std::int64_t']("x_Int64")) != data:
     sys.exit(1)
 
-if list(df.Take['std::int32_t']("x3")) != [5, 6, 7, 8, 9, 10, 11, 12, 13, 14]:
-    sys.exit(1)
+for n in df.GetColumnNames():
+    df.Display(n).Print()


### PR DESCRIPTION
```julia-repl
julia> newtable = (;
                      one_vuint = [[0xcececece, 0xcdcdcdcd], [0xabababab]],
                      two_uint = [0xabababab, 0xefefefef]
                  )
(one_vuint = Vector{UInt32}[[0xcececece, 0xcdcdcdcd], [0xabababab]], two_uint = UInt32[0xabababab, 0xefefefef])

julia> UnROOT.write_rntuple(open("/tmp/a.root", "w"), newtable; rntuple_name="myntuple")

julia> LazyTree("/tmp/a.root", "myntuple")
 Row │ one_vuint                 two_uint
     │ Vector{UInt32}            UInt32
─────┼──────────────────────────────────────
 1   │ [3469659854, 3452816845]  2880154539
 2   │ [2880154539]              4025479151
```

- [x] Investigate why nesting one more level of vector fails
- [x] Make ROOT C++ happy