### PR TITLE
batch reading for TBaskets

### DIFF
--- a/src/root.jl
+++ b/src/root.jl
@@ -538,7 +538,7 @@ end
     readbasket(f::ROOTFile, branch, ith)
     readbasketseek(f::ROOTFile, branch::Union{TBranch, TBranchElement}, seek_pos::Int, nbytes)
 
-The fundamental building block of reading read data from a .root file. Read read one
+The fundamental building block of reading read data from a .root file. Read one
 basket's raw bytes and offsets at a time. These raw bytes and offsets then (potentially) get
 processed by [`interped_data`](@ref).
 


### PR DESCRIPTION
fix #358 

thanks @alexander-held for reminding me to benchmark again

```julia
julia> f() = LazyTree("3148230F-FC33-5240-8EFC-89FF45563A47.root", "Events", r"^Muon")[:]

# before
julia> df = @time f();
 18.882730 seconds (128.33 M allocations: 8.914 GiB, 32.75% gc time, 2.42% compilation time)

julia> df = @time f();
 18.590407 seconds (127.94 M allocations: 8.895 GiB, 33.37% gc time)

# after
julia> df = @time f();
 10.531039 seconds (1.54 M allocations: 5.355 GiB, 12.92% gc time)

julia> df = @time f();
 10.691377 seconds (1.65 M allocations: 5.125 GiB, 12.52% gc time, 1.78% compilation time)

julia> df = @time f();
 11.042397 seconds (1.54 M allocations: 5.119 GiB, 10.94% gc time)
```

for comparison, uproot
```python
In [15]: %%time
    ...: with up.open("./3148230F-FC33-5240-8EFC-89FF45563A47.root") as f:
    ...:     df = f["Events"].arrays(filter_name="Muon*")
CPU times: user 10.5 s, sys: 122 ms, total: 10.6 s
Wall time: 10.5 s
```