### PR TITLE
Add TString recongnition in TString

### DIFF
--- a/src/root.jl
+++ b/src/root.jl
@@ -327,6 +327,7 @@ function _normalize_ftype(fType)
     end
 end
 
+# TODO: there are still a few missing here (see constants.jl)
 const _leaftypeconstlookup = Dict(
                              Const.kBool   => Bool  ,
                              Const.kChar   => Int8  ,
@@ -344,6 +345,7 @@ const _leaftypeconstlookup = Dict(
                              Const.kDouble32 => Float32,
                              Const.kDouble =>   Float64,
                              Const.kFloat => Float32,
+                             Const.kTString => String,
                             )
 
 """

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -71,6 +71,10 @@ function JaggType(f, branch, leaf)
             leaf isa TLeafElement && leaf.fLenType==0 && return Offsetjagg
             return Nojagg
         end
+        if typeof(streamer) <: TStreamerString
+            # TODO: there are for sure also jagged strings, need to find files with those
+            return Nojagg
+        end
         if streamer.fSTLtype == Const.kSTLvector
             (match(r"\[.*\]", leaf.fTitle) !== nothing) && return Offset6jaggjagg
             return Offsetjagg


### PR DESCRIPTION
Before:

```
julia> UnROOT.array(f, "TriggerStats_tree/Monitor_TelPat_0/fReferenceTimeString")
ERROR: type TStreamerString has no field fSTLtype
Stacktrace:
 [1] getproperty(x::UnROOT.TStreamerString, f::Symbol)
   @ Base ./Base.jl:37
 [2] UnROOT.JaggType(f::ROOTFile, branch::UnROOT.TBranchElement_9, leaf::UnROOT.TLeafElement)
   @ UnROOT ~/Dev/UnROOT.jl/src/utils.jl:74
 [3] auto_T_JaggT(f::ROOTFile, branch::UnROOT.TBranchElement_9; customstructs::Dict{String, Type})
   @ UnROOT ~/Dev/UnROOT.jl/src/root.jl:366
 [4] auto_T_JaggT
   @ ~/Dev/UnROOT.jl/src/root.jl:361 [inlined]
 [5] array(f::ROOTFile, branch::UnROOT.TBranchElement_9; raw::Bool)
   @ UnROOT ~/Dev/UnROOT.jl/src/iteration.jl:34
 [6] array(f::ROOTFile, path::String; raw::Bool)
   @ UnROOT ~/Dev/UnROOT.jl/src/iteration.jl:21
 [7] array(f::ROOTFile, path::String)
   @ UnROOT ~/Dev/UnROOT.jl/src/iteration.jl:20
 [8] top-level scope
   @ REPL[4]:1
```

after this PR

```
julia> UnROOT.array(f, "TriggerStats_tree/Monitor_TelPat_0/fReferenceTimeString")
1-element Vector{String}:
 "None"
```

and subsequently also working with `LazyTree` etc:

```
julia> LazyTree(f, "TriggerStats_tree", [r"Monitor_TelPat_\d+/.*String"])
 Row │ Monitor_TelPat_  Monitor_TelPat_  Monitor_TelPat_  Monitor_TelPat_  Monitor_TelPat_  Monitor_TelPat_ 
     │ String           String           String           String           String           String          
─────┼──────────────────────────────────────────────────────────────────────────────────────────────────────
 1   │ None             None             None             None             None             None
```