### PR TITLE
Add stub for ttreeindex to supress warning

### DIFF
--- a/src/bootstrap.jl
+++ b/src/bootstrap.jl
@@ -1402,6 +1402,19 @@ function readfields!(io::IO, fields, ::Type{TFriendElement_2})
     fields[:fOwnFile] = readtype(io, Bool)
 end
 
+# TTreeIndex is a TTree's optional fast-lookup index (TVirtualIndex). UnROOT does
+# not use the index payload, so the bootstrap is a stub — the generic
+# `unpack(::ROOTStreamedObject)` already skips to `preamble.start + preamble.cnt`
+# after `readfields!` returns.
+abstract type TTreeIndex <: ROOTStreamedObject end
+Base.@kwdef struct TTreeIndex_1 <: TTreeIndex
+    cursor::Cursor
+end
+Base.@kwdef struct TTreeIndex_2 <: TTreeIndex
+    cursor::Cursor
+end
+readfields!(io::IO, fields, ::Type{<:TTreeIndex}) = nothing
+
 abstract type TAttBox2D <: ROOTStreamedObject end
 struct TAttBox2D_0 <: TAttBox2D end
 readfields!(c::Cursor, fields, ::Type{TAttBox2D_0}) = nothing


### PR DESCRIPTION
When a `TTreeIndex` is present, UnROOT currently shows a warning (which make some users panic):

```julia
  julia> foff = ROOTFile("/Users/tamasgal/Data/KM3NeT_00000133_00015285.mc.gsg_astro-neutrinos_merged.sirene.jterbr.jpp
  muon_aashower_static.offline.v9.1.root")
  ROOTFile with 4 entries and 44 streamers.
  /Users/tamasgal/Data/KM3NeT_00000133_00015285.mc.gsg_astro-neutrinos_merged.sirene.jterbr.jppmuon_aashower_static.off
  line.v9.1.root
  ┌ Warning: Could not get streamer for 'TTreeIndex' (TKey: UnROOT.TKey32(11058, 4, 57430, 0x76a11d5d, 53, 1,
  219387122, 100, "TTree", "KM3NET_SUMMARYSLICE", ""))
  └ @ UnROOT ~/Dev/UnROOT.jl/src/streamers.jl:255
  ├─ KM3NET_SUMMARYSLICE (TTree)
  │  └─ "KM3NET_SUMMARYSLICE"
  ├─ E (TTree)
  │  └─ "Evt"
  ├─ Head (Head)
  └─ META (TDirectory)
     ├─ JMeta (TNamed)
     ├─ JMeta (TNamed)
     ├─ JMeta (TNamed)
 ...
....
...
```

I added a stub to make it disappear 😉 Maybe we should use this TTreeIndex at some point