### PR TITLE
TNamed access now returns title when inside a TDirectory

### DIFF
--- a/src/root.jl
+++ b/src/root.jl
@@ -203,8 +203,13 @@ function getindex(d::ROOTDirectory, s)
         paths = split(s, '/')
         return d[first(paths)][join(paths[2:end], "/")]
     end
-    tkey = d.keys[findfirst(isequal(s), keys(d))]
+    idx = findfirst(isequal(s), keys(d))
+    isnothing(idx) && throw(KeyError(s))
+    tkey = d.keys[idx]
     streamer = getfield(@__MODULE__, Symbol(tkey.fClassName))
+    if streamer === TNamed
+        return tkey.fTitle
+    end
     S = streamer(d.fobj, tkey, d.refs)
     return S
 end

--- a/test/bootstrapping.jl
+++ b/test/bootstrapping.jl
@@ -172,6 +172,12 @@ end
 
     f = UnROOT.samplefile("issue11_tdirectory.root")
     @test sum(LazyBranch(f, "Data/mytree/Particle0_E")) ≈ 1012.0
+
+    # TNamed inside a TDirectory should return its fTitle string
+    f = UnROOT.samplefile("km3net_online.root")
+    @test f["META/JMeta"] == "JDataWriter"
+    @test startswith(f["META/JDataWriter"], "GIT=12.0.0-alpha.10")
+    @test_throws KeyError f["META/does_not_exist"]
 end
 
 @testset "TBaskets in TTree" begin


### PR DESCRIPTION
Now gives the string back, even if the TNamed is buried inside a Tdirectory